### PR TITLE
Crop Yield Africa use case - initial dataset and example tabular regression

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,6 +10,10 @@ TRAINER_PROFILE="gpu" # cpu/gpu/mps/ddp
 HF_HOME="${PROJECT_ROOT}/.cache/huggingface/" # set or will default to './.cache/huggingface/'
 DATA_DIR="${PROJECT_ROOT}/data/"  # set to your local data folder (for aether), or will default to '${PROJECT_ROOT}/data/'
 
+# When using (and downloading) TESSERA embeddings (e.g., crop yield use case)
+# Note that this folder can get large ...
+TESSERA_EMBEDDINGS_DIR="${PROJECT_ROOT}/data/cache/tessera/"
+
 # Working directories
 # STORAGE_MODE=# or "shared"
 # SHARED_CACHE=# or "/path/to/shared/.cache"

--- a/.env.example
+++ b/.env.example
@@ -10,8 +10,10 @@ TRAINER_PROFILE="gpu" # cpu/gpu/mps/ddp
 HF_HOME="${PROJECT_ROOT}/.cache/huggingface/" # set or will default to './.cache/huggingface/'
 DATA_DIR="${PROJECT_ROOT}/data/"  # set to your local data folder (for aether), or will default to '${PROJECT_ROOT}/data/'
 
-# When using (and downloading) TESSERA embeddings (e.g., crop yield use case)
-# Note that this folder can get large ...
+# Base cache directory for TESSERA.
+# GeoTessera registry/metadata is stored here; large raw source tiles go in the
+# raw/ subfolder. This folder can get very large — point it at an external drive
+# if needed.
 TESSERA_EMBEDDINGS_DIR="${PROJECT_ROOT}/data/cache/tessera/"
 
 # Working directories

--- a/.gitignore
+++ b/.gitignore
@@ -228,3 +228,4 @@ notebooks/01-TvdP-tmp.ipynb
 */source/*
 *.tif # for now
 ..env.swp
+/data/yield_africa/

--- a/configs/data/yield_africa_all.yaml
+++ b/configs/data/yield_africa_all.yaml
@@ -1,0 +1,28 @@
+_target_: src.data.base_datamodule.BaseDataModule
+
+dataset:
+  _target_: src.data.yield_africa_dataset.YieldAfricaDataset
+  data_dir: ${paths.data_dir}
+  modalities:
+    coords: {}
+  use_target_data: true
+  use_features: true
+  use_aux_data: none
+  seed: ${seed}
+  cache_dir: ${paths.cache_dir}
+  # Country/year filters — set to a list to restrict, null to include all.
+  # countries and years select only the listed values;
+  # exclude_countries and exclude_years drop the listed values.
+  countries: null
+  years: null
+  exclude_countries: ["BF"]
+  exclude_years: null
+
+batch_size: 64
+num_workers: 0
+pin_memory: false
+
+split_mode: "random"
+train_val_test_split: [0.7, 0.15, 0.15]
+save_split: false
+seed: ${seed}

--- a/configs/data/yield_africa_all.yaml
+++ b/configs/data/yield_africa_all.yaml
@@ -13,14 +13,19 @@ dataset:
   # Country/year filters — set to a list to restrict, null to include all.
   # countries and years select only the listed values;
   # exclude_countries and exclude_years drop the listed values.
-  countries: null
-  years: null
-  exclude_countries: ["BF"]
+  countries: ["KEN", "RWA", "TAN", "ZAM", "MAL"]
+  years: [2016, 2017, 2018, 2019, 2020, 2021]
+  exclude_countries: null
   exclude_years: null
 
 batch_size: 64
 num_workers: 0
 pin_memory: false
+
+# todo - use spatial split (pre-calculate and then load from file)
+#      - hold out country/year block for validation
+#      - or leave one country out for validation
+#      - normalize data by country (after filtering)
 
 split_mode: "random"
 train_val_test_split: [0.7, 0.15, 0.15]

--- a/configs/data/yield_africa_loco.yaml
+++ b/configs/data/yield_africa_loco.yaml
@@ -10,9 +10,7 @@ dataset:
   use_aux_data: none
   seed: ${seed}
   cache_dir: ${paths.cache_dir}
-  # Country/year filters — set to a list to restrict, null to include all.
-  # countries and years select only the listed values;
-  # exclude_countries and exclude_years drop the listed values.
+  # Include all countries and years so the split file determines the partition.
   countries: ["BF", "BUR", "ETH", "KEN", "MAL", "RWA", "TAN", "ZAM"]
   years: [2014, 2016, 2017, 2018, 2019, 2020, 2021, 2023, 2024]
   exclude_countries: null
@@ -22,12 +20,14 @@ batch_size: 64
 num_workers: 0
 pin_memory: false
 
-# todo - use spatial split (pre-calculate and then load from file)
-#      - hold out country/year block for validation
-#      - or leave one country out for validation
-#      - normalize data by country (after filtering)
-
-split_mode: "random"
-train_val_test_split: [0.7, 0.15, 0.15]
+# Leave-one-country-out split loaded from a pre-generated file.
+# Generate split files first:
+#   python src/data_preprocessing/yield_africa_loco_splits.py --data_dir <data_dir>
+#
+# Override saved_split_file_name at the command line to change the held-out country:
+#   python src/train.py experiment=yield_africa_tabular_loco \
+#     data.saved_split_file_name=split_loco_RWA.pth
+split_mode: "from_file"
+saved_split_file_name: "split_loco_KEN.pth"
 save_split: false
 seed: ${seed}

--- a/configs/data/yield_africa_tessera.yaml
+++ b/configs/data/yield_africa_tessera.yaml
@@ -4,15 +4,18 @@ dataset:
   _target_: src.data.yield_africa_dataset.YieldAfricaDataset
   data_dir: ${paths.data_dir}
   modalities:
-    coords: {}
+    tessera:
+      # size must match the tile_size used when running the preprocessing script.
+      # Default: 9 pixels (set by yield_africa_tessera_preprocess.py --tile_size).
+      size: 9
+      format: npy
+      # year is intentionally omitted: yield_africa fetches per-record year tiles
+      # via the preprocessing script rather than a single bulk-year download.
   use_target_data: true
   use_features: true
   use_aux_data: none
   seed: ${seed}
   cache_dir: ${paths.cache_dir}
-  # Country/year filters — set to a list to restrict, null to include all.
-  # countries and years select only the listed values;
-  # exclude_countries and exclude_years drop the listed values.
   countries: ["BF", "BUR", "ETH", "KEN", "MAL", "RWA", "TAN", "ZAM"]
   years: [2014, 2016, 2017, 2018, 2019, 2020, 2021, 2023, 2024]
   exclude_countries: null
@@ -21,11 +24,6 @@ dataset:
 batch_size: 64
 num_workers: 0
 pin_memory: false
-
-# todo - use spatial split (pre-calculate and then load from file)
-#      - hold out country/year block for validation
-#      - or leave one country out for validation
-#      - normalize data by country (after filtering)
 
 split_mode: "random"
 train_val_test_split: [0.7, 0.15, 0.15]

--- a/configs/experiment/yield_africa_coords_reg.yaml
+++ b/configs/experiment/yield_africa_coords_reg.yaml
@@ -1,0 +1,25 @@
+# @package _global_
+# configs/experiment/yield_africa_tabular_reg.yaml
+# Variant: Tabular features only, full dataset
+
+defaults:
+  - override /model: yield_geoclip_reg
+  - override /data: yield_africa_all
+  - override /metrics: yield_africa_regression
+
+tags: ["yield_africa", "coords_only", "regression"]
+seed: 12345
+
+trainer:
+  min_epochs: 1
+  max_epochs: 50
+
+data:
+  batch_size: 64
+
+logger:
+  wandb:
+    tags: ${tags}
+    group: "yield_africa"
+  aim:
+    experiment: "yield_africa"

--- a/configs/experiment/yield_africa_coords_reg.yaml
+++ b/configs/experiment/yield_africa_coords_reg.yaml
@@ -12,7 +12,7 @@ seed: 12345
 
 trainer:
   min_epochs: 1
-  max_epochs: 50
+  max_epochs: 150
 
 data:
   batch_size: 64

--- a/configs/experiment/yield_africa_fusion_reg.yaml
+++ b/configs/experiment/yield_africa_fusion_reg.yaml
@@ -12,7 +12,7 @@ seed: 12345
 
 trainer:
   min_epochs: 1
-  max_epochs: 50
+  max_epochs: 150
 
 data:
   batch_size: 64

--- a/configs/experiment/yield_africa_fusion_reg.yaml
+++ b/configs/experiment/yield_africa_fusion_reg.yaml
@@ -1,0 +1,25 @@
+# @package _global_
+# configs/experiment/heat_guatemala_fusion_reg.yaml
+# Variant C: GeoClip + tabular fusion
+
+defaults:
+  - override /model: yield_fusion_reg
+  - override /data: yield_africa_all
+  - override /metrics: yield_africa_regression
+
+tags: ["yield_africa", "fusion", "regression"]
+seed: 12345
+
+trainer:
+  min_epochs: 1
+  max_epochs: 50
+
+data:
+  batch_size: 64
+
+logger:
+  wandb:
+    tags: ${tags}
+    group: "yield_africa"
+  aim:
+    experiment: "yield_africa"

--- a/configs/experiment/yield_africa_tabular_loco.yaml
+++ b/configs/experiment/yield_africa_tabular_loco.yaml
@@ -1,0 +1,30 @@
+# @package _global_
+# configs/experiment/yield_africa_tabular_loco.yaml
+# Tabular-only model evaluated with leave-one-country-out split.
+# Default held-out country: KEN (largest, most representative test set).
+#
+# To evaluate on a different held-out country:
+#   python src/train.py experiment=yield_africa_tabular_loco \
+#     data.saved_split_file_name=split_loco_RWA.pth
+
+defaults:
+  - override /model: yield_tabular_reg
+  - override /data: yield_africa_loco
+  - override /metrics: yield_africa_regression
+
+tags: ["yield_africa", "tabular_only", "regression", "loco"]
+seed: 12345
+
+trainer:
+  min_epochs: 1
+  max_epochs: 150
+
+data:
+  batch_size: 64
+
+logger:
+  wandb:
+    tags: ${tags}
+    group: "yield_africa"
+  aim:
+    experiment: "yield_africa"

--- a/configs/experiment/yield_africa_tabular_reg.yaml
+++ b/configs/experiment/yield_africa_tabular_reg.yaml
@@ -12,7 +12,7 @@ seed: 12345
 
 trainer:
   min_epochs: 1
-  max_epochs: 50
+  max_epochs: 150
 
 data:
   batch_size: 64

--- a/configs/experiment/yield_africa_tabular_reg.yaml
+++ b/configs/experiment/yield_africa_tabular_reg.yaml
@@ -1,0 +1,25 @@
+# @package _global_
+# configs/experiment/yield_africa_tabular_reg.yaml
+# Variant: Tabular features only, full dataset
+
+defaults:
+  - override /model: yield_tabular_reg
+  - override /data: yield_africa_all
+  - override /metrics: yield_africa_regression
+
+tags: ["yield_africa", "tabular_only", "regression"]
+seed: 12345
+
+trainer:
+  min_epochs: 1
+  max_epochs: 50
+
+data:
+  batch_size: 64
+
+logger:
+  wandb:
+    tags: ${tags}
+    group: "yield_africa"
+  aim:
+    experiment: "yield_africa"

--- a/configs/experiment/yield_africa_tessera_fusion_reg.yaml
+++ b/configs/experiment/yield_africa_tessera_fusion_reg.yaml
@@ -1,0 +1,31 @@
+# @package _global_
+# configs/experiment/yield_africa_tessera_fusion_reg.yaml
+# Variant: TESSERA spatial encoder + tabular features fusion.
+# Requires:
+#   1. TESSERA tiles pre-fetched:
+#        python src/data_preprocessing/yield_africa_tessera_preprocess.py --data_dir <data_dir>
+#   2. MultiModalEncoder geo_encoder_cfg support.
+
+defaults:
+  - override /model: yield_tessera_fusion_reg
+  - override /data: yield_africa_tessera
+  - override /metrics: yield_africa_regression
+
+tags: ["yield_africa", "tessera_fusion", "regression"]
+seed: 12345
+
+trainer:
+  min_epochs: 1
+  max_epochs: 150
+
+data:
+  batch_size: 64
+  dataset:
+    use_features: true
+
+logger:
+  wandb:
+    tags: ${tags}
+    group: "yield_africa"
+  aim:
+    experiment: "yield_africa"

--- a/configs/experiment/yield_africa_tessera_reg.yaml
+++ b/configs/experiment/yield_africa_tessera_reg.yaml
@@ -1,0 +1,27 @@
+# @package _global_
+# configs/experiment/yield_africa_tessera_reg.yaml
+# Variant: TESSERA spatial encoder only (no tabular features).
+# Requires tiles pre-fetched by:
+#   python src/data_preprocessing/yield_africa_tessera_preprocess.py --data_dir <data_dir>
+
+defaults:
+  - override /model: yield_tessera_reg
+  - override /data: yield_africa_tessera
+  - override /metrics: yield_africa_regression
+
+tags: ["yield_africa", "tessera_only", "regression"]
+seed: 12345
+
+trainer:
+  min_epochs: 1
+  max_epochs: 150
+
+data:
+  batch_size: 64
+
+logger:
+  wandb:
+    tags: ${tags}
+    group: "yield_africa"
+  aim:
+    experiment: "yield_africa"

--- a/configs/metrics/yield_africa_regression.yaml
+++ b/configs/metrics/yield_africa_regression.yaml
@@ -1,0 +1,7 @@
+_target_: src.models.components.metrics.metrics_wrapper.MetricsWrapper
+
+metrics:
+  - _target_: src.models.components.loss_fns.mse_loss.MSELoss
+  - _target_: src.models.components.loss_fns.rmse_loss.RMSELoss
+  - _target_: src.models.components.loss_fns.mae_loss.MAELoss
+  - _target_: src.models.components.metrics.r2.RSquared

--- a/configs/model/geoclip_alignment.yaml
+++ b/configs/model/geoclip_alignment.yaml
@@ -1,7 +1,7 @@
 _target_: src.models.text_alignment_model.TextAlignmentModel
 
-eo_encoder:
-  _target_: src.models.components.eo_encoders.geoclip.GeoClipCoordinateEncoder
+geo_encoder:
+  _target_: src.models.components.geo_encoders.geoclip.GeoClipCoordinateEncoder
 
 text_encoder:
   _target_: src.models.components.text_encoders.clip_text_encoder.ClipTextEncoder

--- a/configs/model/geoclip_llm2clip_alignment.yaml
+++ b/configs/model/geoclip_llm2clip_alignment.yaml
@@ -1,7 +1,7 @@
 _target_: src.models.text_alignment_model.TextAlignmentModel
 
-eo_encoder:
-  _target_: src.models.components.eo_encoders.geoclip.GeoClipCoordinateEncoder
+geo_encoder:
+  _target_: src.models.components.geo_encoders.geoclip.GeoClipCoordinateEncoder
 
 text_encoder:
   _target_: src.models.components.text_encoders.llm2clip_text_encoder.LLM2CLIPTextEncoder

--- a/configs/model/heat_fusion_reg.yaml
+++ b/configs/model/heat_fusion_reg.yaml
@@ -8,8 +8,8 @@
 
 _target_: src.models.predictive_model.PredictiveModel
 
-eo_encoder:
-  _target_: src.models.components.eo_encoders.multimodal_encoder.MultiModalEncoder
+geo_encoder:
+  _target_: src.models.components.geo_encoders.multimodal_encoder.MultiModalEncoder
   use_coords: true
   use_tabular: true
 #  tab_embed_dim: 64
@@ -20,7 +20,7 @@ prediction_head:
   hidden_dim: 256
 
 # GeoClip frozen; tabular projection + head are trained.
-trainable_modules: [eo_encoder, prediction_head]
+trainable_modules: [geo_encoder, prediction_head]
 
 metrics: ${metrics}
 

--- a/configs/model/heat_geoclip_reg.yaml
+++ b/configs/model/heat_geoclip_reg.yaml
@@ -8,8 +8,8 @@
 
 _target_: src.models.predictive_model.PredictiveModel
 
-eo_encoder:
-  _target_: src.models.components.eo_encoders.multimodal_encoder.MultiModalEncoder
+geo_encoder:
+  _target_: src.models.components.geo_encoders.multimodal_encoder.MultiModalEncoder
   use_coords: true
   use_tabular: false
 

--- a/configs/model/heat_tabular_reg.yaml
+++ b/configs/model/heat_tabular_reg.yaml
@@ -10,14 +10,14 @@
 #   1. HeatGuatemalaDataset.tabular_dim reads len(feat_names) from the CSV.
 #   2. BaseDataModule.tabular_dim delegates to the train dataset.
 #   3. PredictiveRegressionModel.setup() calls
-#      self.eo_encoder.build_tabular_branch(self.trainer.datamodule.tabular_dim)
+#      self.geo_encoder.build_tabular_branch(self.trainer.datamodule.tabular_dim)
 
 _target_: src.models.predictive_model.PredictiveModel
 
 metrics: ${metrics}
 
-eo_encoder:
-  _target_: src.models.components.eo_encoders.multimodal_encoder.MultiModalEncoder
+geo_encoder:
+  _target_: src.models.components.geo_encoders.multimodal_encoder.MultiModalEncoder
   use_coords: false
   use_tabular: true
   tab_embed_dim: 64
@@ -28,7 +28,7 @@ prediction_head:
   hidden_dim: 256
 
 # Both encoder and head have trainable parameters.
-trainable_modules: [eo_encoder, prediction_head]
+trainable_modules: [geo_encoder, prediction_head]
 
 optimizer:
   _target_: torch.optim.Adam

--- a/configs/model/predictive_cnn_s2.yaml
+++ b/configs/model/predictive_cnn_s2.yaml
@@ -1,15 +1,15 @@
 _target_: src.models.predictive_model.PredictiveModel
 
-eo_encoder:
-  _target_: src.models.components.eo_encoders.cnn_encoder.CNNEncoder
+geo_encoder:
+  _target_: src.models.components.geo_encoders.cnn_encoder.CNNEncoder
   resnet_version: 18
   freezing_strategy: none
-  eo_data_name: s2
+  geo_data_name: s2
 
 prediction_head:
   _target_: src.models.components.pred_heads.mlp_pred_head.MLPPredictionHead
 
-trainable_modules: [eo_encoder, prediction_head]
+trainable_modules: [geo_encoder, prediction_head]
 
 metrics: ${metrics}
 

--- a/configs/model/predictive_geoclip.yaml
+++ b/configs/model/predictive_geoclip.yaml
@@ -1,7 +1,7 @@
 _target_: src.models.predictive_model.PredictiveModel
 
-eo_encoder:
-  _target_: src.models.components.eo_encoders.geoclip.GeoClipCoordinateEncoder
+geo_encoder:
+  _target_: src.models.components.geo_encoders.geoclip.GeoClipCoordinateEncoder
 
 prediction_head:
   _target_: src.models.components.pred_heads.mlp_pred_head.MLPPredictionHead

--- a/configs/model/yield_fusion_reg.yaml
+++ b/configs/model/yield_fusion_reg.yaml
@@ -15,6 +15,8 @@ prediction_head:
 
 # GeoClip frozen; tabular projection + head are trained.
 trainable_modules: [geo_encoder, prediction_head]
+# Disable L2 normalization before MLP regression to keep magnitude of features
+normalize_features: false
 
 metrics: ${metrics}
 

--- a/configs/model/yield_fusion_reg.yaml
+++ b/configs/model/yield_fusion_reg.yaml
@@ -1,7 +1,7 @@
 _target_: src.models.predictive_model.PredictiveModel
 
-eo_encoder:
-  _target_: src.models.components.eo_encoders.multimodal_encoder.MultiModalEncoder
+geo_encoder:
+  _target_: src.models.components.geo_encoders.multimodal_encoder.MultiModalEncoder
   use_coords: true
   use_tabular: true
 #  tab_embed_dim: 64
@@ -12,7 +12,7 @@ prediction_head:
   hidden_dim: 256
 
 # GeoClip frozen; tabular projection + head are trained.
-trainable_modules: [eo_encoder, prediction_head]
+trainable_modules: [geo_encoder, prediction_head]
 
 metrics: ${metrics}
 

--- a/configs/model/yield_fusion_reg.yaml
+++ b/configs/model/yield_fusion_reg.yaml
@@ -2,16 +2,16 @@ _target_: src.models.predictive_model.PredictiveModel
 
 eo_encoder:
   _target_: src.models.components.eo_encoders.multimodal_encoder.MultiModalEncoder
-  use_coords: false
+  use_coords: true
   use_tabular: true
-  tab_embed_dim: 128
+#  tab_embed_dim: 64
 
 prediction_head:
   _target_: src.models.components.pred_heads.mlp_regression_head.MLPRegressionPredictionHead
   nn_layers: 2
   hidden_dim: 256
 
-# Both encoder and head have trainable parameters.
+# GeoClip frozen; tabular projection + head are trained.
 trainable_modules: [eo_encoder, prediction_head]
 
 metrics: ${metrics}

--- a/configs/model/yield_geoclip_reg.yaml
+++ b/configs/model/yield_geoclip_reg.yaml
@@ -9,6 +9,7 @@ prediction_head:
   _target_: src.models.components.pred_heads.mlp_regression_head.MLPRegressionPredictionHead
   nn_layers: 2
   hidden_dim: 256
+  dropout: 0.2
 
 # Only the prediction head is trained; GeoClip encoder is frozen.
 trainable_modules: [prediction_head]
@@ -19,7 +20,7 @@ optimizer:
   _target_: torch.optim.Adam
   _partial_: true
   lr: 0.001
-  weight_decay: 0.0
+  weight_decay: 1e-4
 
 scheduler:
   _target_: torch.optim.lr_scheduler.ReduceLROnPlateau

--- a/configs/model/yield_geoclip_reg.yaml
+++ b/configs/model/yield_geoclip_reg.yaml
@@ -1,7 +1,7 @@
 _target_: src.models.predictive_model.PredictiveModel
 
-eo_encoder:
-  _target_: src.models.components.eo_encoders.multimodal_encoder.MultiModalEncoder
+geo_encoder:
+  _target_: src.models.components.geo_encoders.multimodal_encoder.MultiModalEncoder
   use_coords: true
   use_tabular: false
 

--- a/configs/model/yield_geoclip_reg.yaml
+++ b/configs/model/yield_geoclip_reg.yaml
@@ -2,17 +2,16 @@ _target_: src.models.predictive_model.PredictiveModel
 
 eo_encoder:
   _target_: src.models.components.eo_encoders.multimodal_encoder.MultiModalEncoder
-  use_coords: false
-  use_tabular: true
-  tab_embed_dim: 128
+  use_coords: true
+  use_tabular: false
 
 prediction_head:
   _target_: src.models.components.pred_heads.mlp_regression_head.MLPRegressionPredictionHead
   nn_layers: 2
   hidden_dim: 256
 
-# Both encoder and head have trainable parameters.
-trainable_modules: [eo_encoder, prediction_head]
+# Only the prediction head is trained; GeoClip encoder is frozen.
+trainable_modules: [prediction_head]
 
 metrics: ${metrics}
 

--- a/configs/model/yield_geoclip_reg.yaml
+++ b/configs/model/yield_geoclip_reg.yaml
@@ -13,6 +13,8 @@ prediction_head:
 
 # Only the prediction head is trained; GeoClip encoder is frozen.
 trainable_modules: [prediction_head]
+# Disable L2 normalization before MLP regression to keep magnitude of features
+normalize_features: false
 
 metrics: ${metrics}
 

--- a/configs/model/yield_tabular_reg.yaml
+++ b/configs/model/yield_tabular_reg.yaml
@@ -15,6 +15,8 @@ prediction_head:
 
 # Both encoder and head have trainable parameters.
 trainable_modules: [geo_encoder, prediction_head]
+# Disable L2 normalization before MLP regression to keep magnitude of features
+normalize_features: false
 
 metrics: ${metrics}
 

--- a/configs/model/yield_tabular_reg.yaml
+++ b/configs/model/yield_tabular_reg.yaml
@@ -1,7 +1,7 @@
 _target_: src.models.predictive_model.PredictiveModel
 
-eo_encoder:
-  _target_: src.models.components.eo_encoders.multimodal_encoder.MultiModalEncoder
+geo_encoder:
+  _target_: src.models.components.geo_encoders.multimodal_encoder.MultiModalEncoder
   use_coords: false
   use_tabular: true
   tab_embed_dim: 128
@@ -12,7 +12,7 @@ prediction_head:
   hidden_dim: 256
 
 # Both encoder and head have trainable parameters.
-trainable_modules: [eo_encoder, prediction_head]
+trainable_modules: [geo_encoder, prediction_head]
 
 metrics: ${metrics}
 

--- a/configs/model/yield_tabular_reg.yaml
+++ b/configs/model/yield_tabular_reg.yaml
@@ -4,12 +4,14 @@ geo_encoder:
   _target_: src.models.components.geo_encoders.multimodal_encoder.MultiModalEncoder
   use_coords: false
   use_tabular: true
-  tab_embed_dim: 128
+  tab_embed_dim: 256
+  tabular_dropout: 0.2
 
 prediction_head:
   _target_: src.models.components.pred_heads.mlp_regression_head.MLPRegressionPredictionHead
   nn_layers: 2
   hidden_dim: 256
+  dropout: 0.2
 
 # Both encoder and head have trainable parameters.
 trainable_modules: [geo_encoder, prediction_head]
@@ -20,7 +22,7 @@ optimizer:
   _target_: torch.optim.Adam
   _partial_: true
   lr: 0.001
-  weight_decay: 0.0
+  weight_decay: 1e-4
 
 scheduler:
   _target_: torch.optim.lr_scheduler.ReduceLROnPlateau

--- a/configs/model/yield_tabular_reg.yaml
+++ b/configs/model/yield_tabular_reg.yaml
@@ -1,0 +1,33 @@
+_target_: src.models.predictive_model.PredictiveModel
+
+eo_encoder:
+  _target_: src.models.components.eo_encoders.multimodal_encoder.MultiModalEncoder
+  use_coords: false
+  use_tabular: true
+  tab_embed_dim: 128
+
+prediction_head:
+  _target_: src.models.components.pred_heads.mlp_regression_head.MLPRegressionPredictionHead
+  nn_layers: 2
+  hidden_dim: 64
+
+# Both encoder and head have trainable parameters.
+trainable_modules: [eo_encoder, prediction_head]
+
+metrics: ${metrics}
+
+optimizer:
+  _target_: torch.optim.Adam
+  _partial_: true
+  lr: 0.001
+  weight_decay: 0.0001
+
+scheduler:
+  _target_: torch.optim.lr_scheduler.ReduceLROnPlateau
+  _partial_: true
+  mode: min
+  factor: 0.1
+  patience: 10
+
+loss_fn:
+  _target_: src.models.components.loss_fns.huber_loss.HuberLoss

--- a/configs/model/yield_tessera_fusion_reg.yaml
+++ b/configs/model/yield_tessera_fusion_reg.yaml
@@ -1,11 +1,19 @@
 _target_: src.models.predictive_model.PredictiveModel
 
+# MultiModalEncoder with a pluggable geo encoder.
+# The geo_encoder_cfg replaces the hardcoded GeoClipCoordinateEncoder with
+# AverageEncoder(tessera), so the spatial branch uses inter-annual phenology
+# instead of static coordinate embeddings.
 geo_encoder:
   _target_: src.models.components.geo_encoders.multimodal_encoder.MultiModalEncoder
   use_coords: true
   use_tabular: true
   tab_embed_dim: 256
   tabular_dropout: 0.2
+  geo_encoder_cfg:
+    _target_: src.models.components.geo_encoders.average_encoder.AverageEncoder
+    geo_data_name: tessera
+    # output_dim defaults to 128; no projection needed.
 
 prediction_head:
   _target_: src.models.components.pred_heads.mlp_regression_head.MLPRegressionPredictionHead
@@ -13,7 +21,7 @@ prediction_head:
   hidden_dim: 256
   dropout: 0.2
 
-# GeoClip frozen; tabular projection + head are trained.
+# geo_encoder includes the tessera AverageEncoder + tabular branch; head is always trained.
 trainable_modules: [geo_encoder, prediction_head]
 
 metrics: ${metrics}

--- a/configs/model/yield_tessera_fusion_reg.yaml
+++ b/configs/model/yield_tessera_fusion_reg.yaml
@@ -23,6 +23,8 @@ prediction_head:
 
 # geo_encoder includes the tessera AverageEncoder + tabular branch; head is always trained.
 trainable_modules: [geo_encoder, prediction_head]
+# Disable L2 normalization before MLP regression to keep magnitude of features
+normalize_features: false
 
 metrics: ${metrics}
 

--- a/configs/model/yield_tessera_reg.yaml
+++ b/configs/model/yield_tessera_reg.yaml
@@ -1,11 +1,9 @@
 _target_: src.models.predictive_model.PredictiveModel
 
 geo_encoder:
-  _target_: src.models.components.geo_encoders.multimodal_encoder.MultiModalEncoder
-  use_coords: true
-  use_tabular: true
-  tab_embed_dim: 256
-  tabular_dropout: 0.2
+  _target_: src.models.components.geo_encoders.average_encoder.AverageEncoder
+  geo_data_name: tessera
+  # output_dim defaults to 128 (the native tessera channel count); no projection.
 
 prediction_head:
   _target_: src.models.components.pred_heads.mlp_regression_head.MLPRegressionPredictionHead
@@ -13,7 +11,6 @@ prediction_head:
   hidden_dim: 256
   dropout: 0.2
 
-# GeoClip frozen; tabular projection + head are trained.
 trainable_modules: [geo_encoder, prediction_head]
 
 metrics: ${metrics}

--- a/configs/model/yield_tessera_reg.yaml
+++ b/configs/model/yield_tessera_reg.yaml
@@ -12,6 +12,8 @@ prediction_head:
   dropout: 0.2
 
 trainable_modules: [geo_encoder, prediction_head]
+# Disable L2 normalization before MLP regression to keep magnitude of features
+normalize_features: false
 
 metrics: ${metrics}
 

--- a/notebooks/06-TvdP-inference-language-alignment.ipynb
+++ b/notebooks/06-TvdP-inference-language-alignment.ipynb
@@ -119,8 +119,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from src.models.components.eo_encoders.cnn_encoder import CNNEncoder\n",
-    "from src.models.components.eo_encoders.geoclip import GeoClipCoordinateEncoder\n",
+    "from src.models.components.geo_encoders.cnn_encoder import CNNEncoder\n",
+    "from src.models.components.geo_encoders.geoclip import GeoClipCoordinateEncoder\n",
     "from src.models.components.loss_fns.bce_loss import BCELoss\n",
     "from src.models.components.loss_fns.clip_loss import ClipLoss\n",
     "from src.models.components.pred_heads.mlp_pred_head import MLPPredictionHead\n",

--- a/src/data/yield_africa_dataset.py
+++ b/src/data/yield_africa_dataset.py
@@ -9,13 +9,23 @@ They do NOT need to be listed in `modalities`.
 """
 
 import logging
+import os
 from typing import Any, Dict, List, override
 
+import pandas as pd
 import torch
 
 from src.data.base_dataset import BaseDataset
 
+# Number of channels in a TESSERA embedding tile (fixed by the geotessera model).
+_TESSERA_CHANNELS = 128
+
 log = logging.getLogger(__name__)
+
+# Fixed ordered list of all countries in the full dataset.
+# Used to produce a consistent one-hot encoding regardless of which
+# countries are present after filtering.
+_ALL_COUNTRIES = ["BF", "BUR", "ETH", "KEN", "MAL", "RWA", "TAN", "ZAM"]
 
 
 class YieldAfricaDataset(BaseDataset):
@@ -34,6 +44,12 @@ class YieldAfricaDataset(BaseDataset):
     `implemented_mod = {"coords"}` because tabular features live directly in
     the model-ready CSV and are picked up via the `feat_` column prefix.
     They do NOT need to be listed in `modalities`.
+
+    In addition to the CSV feat_* columns, `year` and one-hot `country`
+    encodings are injected as `feat_year` and `feat_country_{CODE}` so that
+    the model can condition on inter-annual and cross-country variation.
+    The one-hot set always covers `_ALL_COUNTRIES` (8 countries) so that
+    `tabular_dim` is stable regardless of the country filter applied.
     """
 
     def __init__(
@@ -59,12 +75,27 @@ class YieldAfricaDataset(BaseDataset):
             dataset_name="yield_africa",
             seed=seed,
             cache_dir=cache_dir,
-            implemented_mod={"coords"},
+            implemented_mod={"coords", "tessera"},
             mock=mock,
             use_features=use_features,
         )
 
-        # Apply country/year filters to self.df and rebuild records if needed.
+        # Inject year and country one-hot columns as feat_* so that
+        # get_records() picks them up automatically.  Build all new columns in
+        # one concat to avoid pandas PerformanceWarning from repeated assignment.
+        if use_features and "year" in self.df.columns and "country" in self.df.columns:
+            # Normalise feat_year to the same scale as the pre-scaled CSV feat_* columns
+            # (roughly zero-mean, unit-std) so it doesn't dominate LayerNorm.
+            _YEAR_MEAN = 2018.0
+            _YEAR_STD = 2.0
+            new_cols: Dict[str, Any] = {
+                "feat_year": (self.df["year"].astype(float) - _YEAR_MEAN) / _YEAR_STD
+            }
+            for code in _ALL_COUNTRIES:
+                new_cols[f"feat_country_{code}"] = (self.df["country"] == code).astype(float)
+            self.df = pd.concat([self.df, pd.DataFrame(new_cols, index=self.df.index)], axis=1)
+
+        # Apply country/year filters to self.df and rebuild records.
         # BaseDataset.__init__ has already loaded the CSV; filtering here avoids
         # touching BaseDataset and keeps the logic use-case specific.
         n_before = len(self.df)
@@ -80,11 +111,44 @@ class YieldAfricaDataset(BaseDataset):
         n_after = len(self.df)
         if n_after != n_before:
             log.info(f"Country/year filter: {n_before} → {n_after} records ({n_before - n_after} excluded)")
-            self.records = self.get_records()
+
+        # get_records() mutates self.use_aux_data in place (replacing pattern
+        # dicts with resolved column-name lists), so reset it from the original
+        # parameter before calling it a second time.
+        if use_aux_data is None or use_aux_data == "all":
+            self.use_aux_data = {
+                "aux": {"pattern": "^aux_(?!.*top).*"},
+                "top": {"pattern": "^aux_.*top.*"},
+            }
+        elif isinstance(use_aux_data, dict):
+            self.use_aux_data = use_aux_data
+        else:
+            self.use_aux_data = None
+
+        # Always rebuild so feat_year / feat_country_* are reflected in
+        # self.feat_names and self.tabular_dim.
+        self.records = self.get_records()
 
     def setup(self) -> None:
-        """No files to download or prepare for this dataset."""
-        return
+        """Check for requested modality data; warn if TESSERA tiles are absent.
+
+        Unlike other datasets, TESSERA tiles for yield_africa vary per record
+        year and must be pre-fetched with the preprocessing script:
+            python src/data_preprocessing/yield_africa_tessera_preprocess.py
+
+        setup_tessera() is intentionally not called here because it uses a
+        single fixed year for bulk download, which is incompatible with the
+        multi-year nature of this dataset.
+        """
+        if "tessera" in self.modalities:
+            tessera_dir = os.path.join(self.data_dir, "eo", "tessera")
+            if not os.path.exists(tessera_dir) or len(os.listdir(tessera_dir)) == 0:
+                log.warning(
+                    "TESSERA tiles not found at %s. "
+                    "Run src/data_preprocessing/yield_africa_tessera_preprocess.py "
+                    "to pre-fetch tiles. Missing tiles will fall back to zero tensors.",
+                    tessera_dir,
+                )
 
     @override
     def __getitem__(self, idx: int) -> Dict[str, Any]:
@@ -96,6 +160,16 @@ class YieldAfricaDataset(BaseDataset):
                 sample["eo"]["coords"] = torch.tensor(
                     [row["lat"], row["lon"]], dtype=torch.float32
                 )
+            elif modality == "tessera":
+                tile_path = row["tessera_path"]
+                if os.path.exists(tile_path):
+                    sample["eo"]["tessera"] = self.load_npy(tile_path)
+                else:
+                    size = self.modalities["tessera"].get("size", 9)
+                    log.debug("TESSERA tile missing: %s — using zero fallback.", tile_path)
+                    sample["eo"]["tessera"] = torch.zeros(
+                        _TESSERA_CHANNELS, size, size, dtype=torch.float32
+                    )
 
         if self.use_features and self.feat_names:
             sample["eo"]["tabular"] = torch.tensor(

--- a/src/data/yield_africa_dataset.py
+++ b/src/data/yield_africa_dataset.py
@@ -1,0 +1,120 @@
+"""Yield Africa dataset.
+
+Location: src/data/yield_africa_dataset.py
+
+Crop yield regression use case for East/Southern Africa.
+Tabular features (soil, climate, etc.) live in the model-ready CSV as feat_*
+columns and are picked up automatically by BaseDataset.get_records().
+They do NOT need to be listed in `modalities`.
+"""
+
+import logging
+from typing import Any, Dict, List, override
+
+import torch
+
+from src.data.base_dataset import BaseDataset
+
+log = logging.getLogger(__name__)
+
+
+class YieldAfricaDataset(BaseDataset):
+    """Dataset for the crop yield regression use case (East/Southern Africa).
+
+    CSV layout expected:
+      - name_loc        : unique location identifier
+      - lat, lon        : WGS84 coordinates
+      - target_*        : crop yield target(s) [t/ha]
+      - feat_*          : tabular features (soil properties, climate indices, etc.)
+      - aux_*           : auxiliary data columns (optional)
+      - country, year   : metadata columns used for optional filtering
+
+    Modality design note
+    --------------------
+    `implemented_mod = {"coords"}` because tabular features live directly in
+    the model-ready CSV and are picked up via the `feat_` column prefix.
+    They do NOT need to be listed in `modalities`.
+    """
+
+    def __init__(
+        self,
+        data_dir: str,
+        modalities: dict,
+        use_target_data: bool = True,
+        use_aux_data: Dict[str, Any] | str = None,
+        seed: int = 12345,
+        cache_dir: str = None,
+        mock: bool = False,
+        use_features: bool = True,
+        countries: List[str] | None = None,
+        years: List[int] | None = None,
+        exclude_countries: List[str] | None = None,
+        exclude_years: List[int] | None = None,
+    ) -> None:
+        super().__init__(
+            data_dir=data_dir,
+            modalities=modalities,
+            use_target_data=use_target_data,
+            use_aux_data=use_aux_data,
+            dataset_name="yield_africa",
+            seed=seed,
+            cache_dir=cache_dir,
+            implemented_mod={"coords"},
+            mock=mock,
+            use_features=use_features,
+        )
+
+        # Apply country/year filters to self.df and rebuild records if needed.
+        # BaseDataset.__init__ has already loaded the CSV; filtering here avoids
+        # touching BaseDataset and keeps the logic use-case specific.
+        n_before = len(self.df)
+        if countries is not None and "country" in self.df.columns:
+            self.df = self.df[self.df["country"].isin(countries)].reset_index(drop=True)
+        if years is not None and "year" in self.df.columns:
+            self.df = self.df[self.df["year"].isin(years)].reset_index(drop=True)
+        if exclude_countries is not None and "country" in self.df.columns:
+            self.df = self.df[~self.df["country"].isin(exclude_countries)].reset_index(drop=True)
+        if exclude_years is not None and "year" in self.df.columns:
+            self.df = self.df[~self.df["year"].isin(exclude_years)].reset_index(drop=True)
+
+        n_after = len(self.df)
+        if n_after != n_before:
+            log.info(f"Country/year filter: {n_before} → {n_after} records ({n_before - n_after} excluded)")
+            self.records = self.get_records()
+
+    def setup(self) -> None:
+        """No files to download or prepare for this dataset."""
+        return
+
+    @override
+    def __getitem__(self, idx: int) -> Dict[str, Any]:
+        row = self.records[idx]
+        sample: Dict[str, Any] = {"eo": {}}
+
+        for modality in self.modalities:
+            if modality == "coords":
+                sample["eo"]["coords"] = torch.tensor(
+                    [row["lat"], row["lon"]], dtype=torch.float32
+                )
+
+        if self.use_features and self.feat_names:
+            sample["eo"]["tabular"] = torch.tensor(
+                [row[k] for k in self.feat_names], dtype=torch.float32
+            )
+
+        if self.use_target_data:
+            sample["target"] = torch.tensor(
+                [row[k] for k in self.target_names], dtype=torch.float32
+            )
+
+        if self.use_aux_data:
+            sample["aux"] = {}
+            for aux_cat, vals in self.use_aux_data.items():
+                if aux_cat == "aux":
+                    sample["aux"][aux_cat] = torch.tensor(
+                        [row[v] for v in vals], dtype=torch.float32
+                    )
+                else:
+                    sample["aux"][aux_cat] = [row[v] for v in vals]
+
+        return sample

--- a/src/data_preprocessing/make_model_ready_yield_africa.py
+++ b/src/data_preprocessing/make_model_ready_yield_africa.py
@@ -679,7 +679,7 @@ if __name__ == "__main__":
     ap.add_argument(
         "--out_csv",
         required=True,
-        help="Path for the output model-ready CSV (e.g. data/yield_africa/model_ready_yield-africa.csv)",
+        help="Path for the output model-ready CSV (e.g. data/yield_africa/model_ready_yield_africa.csv)",
     )
     ap.add_argument(
         "--out_parquet",

--- a/src/data_preprocessing/make_model_ready_yield_africa.py
+++ b/src/data_preprocessing/make_model_ready_yield_africa.py
@@ -1,0 +1,735 @@
+"""Build model-ready CSV/Parquet for the crop yield Africa use case
+(data/yield_africa/model_ready_yield-africa.csv).
+
+Features:
+- Load raw dataset (CSV or Parquet)
+- Compute derived features (CN_ratio, layer deltas, WHC proxy, aridity index)
+- Apply log transforms to skewed features
+- Fit StandardScaler on train split only
+- Encode categorical features as integer indices
+- Remove yield outliers beyond 3 IQR
+- Preserve metadata columns
+- Save fitted transformers for inference-time reuse
+- Calculate and save spatial cross-validation splits
+"""
+
+import argparse
+import json
+import logging
+import warnings
+from pathlib import Path
+from typing import Any, Dict, List, Tuple
+
+import joblib
+import numpy as np
+import pandas as pd
+import torch
+from sklearn.preprocessing import LabelEncoder, StandardScaler
+
+log = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+MODEL_READY_DATA_NAME = "yield_africa"
+
+TRAIN_COUNTRIES = ["BUR", "ETH", "KEN", "MAL", "RWA", "TAN", "ZAM"]
+
+SPATIAL_SPLIT_BLOCK_SIZE_KM = 50.0
+SPATIAL_SPLIT_N_SPLITS = 7
+
+CONTINUOUS_FEATURES = [
+    # Soil features
+    "C_0_20",
+    "C_20_50",
+    "N_0_20",
+    "N_20_50",
+    "P_0_20",
+    "P_20_50",
+    "MA_0_20",
+    "MA_20_50",
+    "PO_0_20",
+    "PO_20_50",
+    "pH_0_20",
+    "pH_20_50",
+    "BD_0_20",
+    "BD_20_50",
+    "ECX_0_20",
+    "ECX_20_50",
+    "CA_0_20",
+    "CA_20_50",
+    # Climate features
+    "PrecJJA",
+    "PrecMAM",
+    "PrecSON",
+    "PrecDJF",
+    "TaveJJA",
+    "TaveMAM",
+    "TaveSON",
+    "TaveDJF",
+    "TmaxJJA",
+    "TmaxMAM",
+    "TmaxSON",
+    "TmaxDJF",
+    "TminJJA",
+    "TminMAM",
+    "TminSON",
+    "TminDJF",
+    "CMD",
+    "Eref",
+    "MAP",
+    "MAT",
+    "TD",
+    "MWMT",
+    "MCMT",
+    "DD_above_5",
+    "DD_above_18",
+    "DD_below_18",
+    # Terrain features
+    "DEM",
+    "Slope",
+    "Aspect",
+    "CHILI",
+    "Top_div",
+    # Land cover / context
+    "Tree_c",
+    "Dist_water",
+    "Paved",
+    "Unpaved",
+    "Pop_10km",
+    # Derived features (computed automatically)
+    "CN_ratio",
+    "C_layer_delta",
+    "BD_layer_delta",
+    "WHC_proxy",
+    "aridity_index",
+]
+
+# Categorical columns that are actual tabular inputs to the regression model (feat_ prefix).
+# TX_*_cl are soil texture classes — they are not derived from a paired numerical column.
+TABULAR_CATEGORICAL_FEATURES = [
+    "TX_0_20_cl",
+    "TX_20_50_cl",
+]
+
+# Categorical columns derived from their paired numerical columns (same name without _cl).
+# Used for caption generation (aux_ prefix).
+AUX_FEATURES = [
+    # target (classified)
+    "Yld_ton_ha_cl",
+    # soil features
+    "C_0_20_cl",
+    "C_20_50_cl",
+    "N_0_20_cl",
+    "N_20_50_cl",
+    "P_0_20_cl",
+    "P_20_50_cl",
+    "MA_0_20_cl",
+    "MA_20_50_cl",
+    "PO_0_20_cl",
+    "PO_20_50_cl",
+    "pH_0_20_cl",
+    "pH_20_50_cl",
+    "BD_0_20_cl",
+    "BD_20_50_cl",
+    "ECX_0_20_cl",
+    "ECX_20_50_cl",
+    "CA_0_20_cl",
+    "CA_20_50_cl",
+    # climate features
+    "PrecJJA_cl",
+    "PrecMAM_cl",
+    "PrecSON_cl",
+    "PrecDJF_cl",
+    "TaveJJA_cl",
+    "TaveMAM_cl",
+    "TaveSON_cl",
+    "TaveDJF_cl",
+    "TmaxJJA_cl",
+    "TmaxMAM_cl",
+    "TmaxSON_cl",
+    "TmaxDJF_cl",
+    "TminJJA_cl",
+    "TminMAM_cl",
+    "TminSON_cl",
+    "TminDJF_cl",
+    "CMD_cl",
+    "Eref_cl",
+    "MAP_cl",
+    "MAT_cl",
+    "TD_cl",
+    "MCMT_cl",
+    "MWMT_cl",
+    "DD_above_5_cl",
+    "DD_above_18_cl",
+    "DD_below_18_cl",
+    # terrain features
+    "DEM_cl",
+    "Slope_cl",
+    "Aspect_cl",
+    "Landform_cl",
+    "CHILI_cl",
+    "Top_div_cl",
+    # land cover / context
+    "GLAD_cl",
+    "Tree_c_cl",
+    "Dist_water_cl",
+    "Paved_cl",
+    "Unpaved_cl",
+    "Pop_10km_cl",
+]
+
+LOG_TRANSFORM_FEATURES = ["Dist_water", "Paved", "Unpaved", "Pop_10km"]
+
+TARGET_COLUMNS = ["Yld_ton_ha"]
+
+NAME_LOC_COLUMN = "ID"
+
+METADATA_COLUMNS = ["Lat", "Lon", "Country", "Year", "Location_accuracy"]
+
+# Saxton & Rawls (2006) Table 3-derived AWC (FC - WP)
+# Conditions: ~2.5% OM, no salinity/gravel/density adjustment
+# "Plant avail." (%v) converted to mm/m via mm/m = (%v) * 10
+# (because 1% v/v = 0.01 m³/m³ = 10 mm per m soil)
+# Values are in mm/m (approximate field capacity - wilting point)
+WHC_LOOKUP_SAXTON_RAWLS_2006_OM2P5 = {
+    "Sand": 50,
+    "Loamy sand": 70,
+    "Sandy loam": 100,
+    "Loam": 140,
+    "Silt loam": 200,
+    "Silt": 250,
+    "Sandy clay loam": 100,
+    "Clay loam": 140,
+    "Silty clay loam": 170,
+    "Silty clay": 140,
+    "Sandy clay": 110,
+    "Clay": 120,
+}
+
+# ---------------------------------------------------------------------------
+# Preprocessing functions
+# ---------------------------------------------------------------------------
+
+def build_column_rename_map(
+    continuous_features: List[str],
+    tabular_categorical_features: List[str],
+    aux_features: List[str],
+    target_columns: List[str],
+    name_loc_column: str,
+    metadata_columns: List[str],
+) -> Dict[str, str]:
+    """Build a column rename mapping that standardises predictor and target names.
+
+    Convention:
+    - Numerical predictors and tabular categorical features: ``feat_{original.lower()}``
+    - Aux/caption features (derived categorical classes): ``aux_{original.lower()}``
+    - Target columns: ``target_{original.lower()}``
+    - Name-location column: ``name_loc``
+    - Metadata columns: ``{original.lower()}``
+    """
+    rename: Dict[str, str] = {}
+    for col in continuous_features:
+        rename[col] = f"feat_{col.lower()}"
+    for col in tabular_categorical_features:
+        rename[col] = f"feat_{col.lower()}"
+    for col in aux_features:
+        rename[col] = f"aux_{col.lower()}"
+    for col in target_columns:
+        rename[col] = f"target_{col.lower()}"
+    for col in metadata_columns:
+        rename[col] = col.lower()
+    if name_loc_column is not None:
+        rename[name_loc_column] = "name_loc"
+    return rename
+
+
+def compute_derived_features(df: pd.DataFrame) -> pd.DataFrame:
+    """Compute derived features from raw measurements."""
+    df = df.copy()
+
+    # C:N ratio (guard against division by zero)
+    df["CN_ratio"] = np.where(
+        df["N_0_20"] > 0,
+        df["C_0_20"] / df["N_0_20"],
+        np.nan,
+    )
+
+    # Layer deltas (stratification indicators)
+    df["C_layer_delta"] = df["C_0_20"] - df["C_20_50"]
+    df["BD_layer_delta"] = df["BD_0_20"] - df["BD_20_50"]
+
+    # Water Holding Capacity proxy from texture lookup, adjusted by bulk density
+    _whc_lookup_lower = {k.lower(): v for k, v in WHC_LOOKUP_SAXTON_RAWLS_2006_OM2P5.items()}
+    df["WHC_proxy"] = (
+        df["TX_0_20_cl"]
+        .astype(str)
+        .str.lower()
+        .map(_whc_lookup_lower)
+        .fillna(WHC_LOOKUP_SAXTON_RAWLS_2006_OM2P5["Sandy loam"])
+    )
+
+    # Adjust WHC by bulk density (inverse relationship, reference BD = 1.3 g/cm³)
+    bd_factor = np.where(df["BD_0_20"] > 0, 1.3 / df["BD_0_20"], 1.0)
+    df["WHC_proxy"] = df["WHC_proxy"] * bd_factor
+
+    # Aridity index (guard against MAP=0)
+    df["aridity_index"] = np.where(df["MAP"] > 0, df["CMD"] / df["MAP"], np.nan)
+
+    return df
+
+
+def apply_log_transforms(df: pd.DataFrame, log_transform_features: List[str]) -> pd.DataFrame:
+    """Apply log(x + 1) transform to skewed features."""
+    df = df.copy()
+    for col in log_transform_features:
+        if col in df.columns:
+            df[col] = np.log1p(np.maximum(df[col], 0))
+    return df
+
+
+def remove_yield_outliers(
+    df: pd.DataFrame,
+    target_col: str = "Yld_ton_ha",
+    iqr_multiplier: float = 3.0,
+) -> Tuple[pd.DataFrame, pd.Series]:
+    """Remove yield outliers beyond IQR threshold."""
+    if target_col not in df.columns:
+        warnings.warn(f"Target column '{target_col}' not found; skipping outlier removal")
+        return df, pd.Series([False] * len(df), index=df.index)
+
+    q1 = df[target_col].quantile(0.25)
+    q3 = df[target_col].quantile(0.75)
+    iqr = q3 - q1
+    lower_bound = q1 - iqr_multiplier * iqr
+    upper_bound = q3 + iqr_multiplier * iqr
+    outlier_mask = (df[target_col] < lower_bound) | (df[target_col] > upper_bound)
+
+    n_outliers = outlier_mask.sum()
+    if n_outliers > 0:
+        log.info(
+            f"Removing {n_outliers} yield outliers (< {lower_bound:.2f} or > {upper_bound:.2f} t/ha)"
+        )
+
+    return df[~outlier_mask].copy(), outlier_mask
+
+
+def fit_scaler(df: pd.DataFrame, continuous_features: List[str]) -> StandardScaler:
+    """Fit StandardScaler on continuous features."""
+    available_features = [f for f in continuous_features if f in df.columns]
+    if len(available_features) < len(continuous_features):
+        missing = set(continuous_features) - set(available_features)
+        warnings.warn(f"Missing continuous features: {missing}")
+    scaler = StandardScaler()
+    scaler.fit(df[available_features])
+    return scaler
+
+
+def apply_scaler(
+    df: pd.DataFrame,
+    scaler: StandardScaler,
+    continuous_features: List[str],
+) -> pd.DataFrame:
+    """Apply fitted StandardScaler to continuous features."""
+    df = df.copy()
+    available_features = [f for f in continuous_features if f in df.columns]
+    df[available_features] = scaler.transform(df[available_features])
+    return df
+
+
+def fit_label_encoders(
+    df: pd.DataFrame,
+    categorical_features: List[str],
+) -> Dict[str, LabelEncoder]:
+    """Fit LabelEncoders for categorical features."""
+    encoders = {}
+    for col in categorical_features:
+        if col not in df.columns:
+            warnings.warn(f"Categorical feature '{col}' not found; skipping")
+            continue
+        encoder = LabelEncoder()
+        encoder.fit(df[col].dropna())
+        encoders[col] = encoder
+        log.info(f"  {col}: {len(encoder.classes_)} classes")
+    return encoders
+
+
+def apply_label_encoders(
+    df: pd.DataFrame,
+    encoders: Dict[str, LabelEncoder],
+    categorical_features: List[str],
+) -> pd.DataFrame:
+    """Apply fitted LabelEncoders to categorical features."""
+    df = df.copy()
+    for col in categorical_features:
+        if col not in df.columns:
+            continue
+        if col not in encoders:
+            warnings.warn(f"No encoder found for '{col}'; skipping")
+            continue
+        encoder = encoders[col]
+        df[col] = df[col].apply(
+            lambda x: encoder.transform([x])[0] if x in encoder.classes_ else -1
+        )
+    return df
+
+
+def calculate_spatial_splits(
+    df: pd.DataFrame,
+    block_size_km: float = 50.0,
+    n_splits: int = 7,
+    lat_col: str = "lat",
+    lon_col: str = "lon",
+    name_loc_col: str = "name_loc",
+    save_path: str | Path | None = None,
+) -> Dict[str, Any]:
+    """Calculate spatial cross-validation splits using a grid-based blocking approach."""
+    log.info(f"Calculating spatial splits with block size {block_size_km}km and {n_splits} folds")
+
+    if "split" in df.columns:
+        train_df = df[df["split"] == "train"].copy()
+        log.info(f"Filtered to training split: {len(train_df)} samples")
+    else:
+        train_df = df.copy()
+        log.info(f"No 'split' column found; using all {len(train_df)} samples for spatial splits")
+
+    # Approx conversion: 1 deg ~ 111 km
+    block_size_deg = block_size_km / 111.0
+    train_df["lat_grid"] = np.floor(train_df[lat_col] / block_size_deg)
+    train_df["lon_grid"] = np.floor(train_df[lon_col] / block_size_deg)
+    train_df["block_id"] = (
+        train_df["lat_grid"].astype(str) + "_" + train_df["lon_grid"].astype(str)
+    )
+
+    unique_blocks = train_df["block_id"].unique()
+    log.info(f"Created {len(unique_blocks)} spatial blocks")
+
+    # Greedy bin packing: assign blocks largest-first to the smallest fold
+    block_counts = train_df["block_id"].value_counts().sort_values(ascending=False)
+    fold_samples = [0] * n_splits
+    fold_block_ids: List[List[str]] = [[] for _ in range(n_splits)]
+
+    for block_id, count in block_counts.items():
+        smallest_fold = int(np.argmin(fold_samples))
+        fold_samples[smallest_fold] += count
+        fold_block_ids[smallest_fold].append(block_id)
+
+    block_to_names = train_df.groupby("block_id")[name_loc_col].unique().to_dict()
+
+    splits: Dict[str, Any] = {}
+    for fold in range(n_splits):
+        val_names = [
+            name
+            for bid in fold_block_ids[fold]
+            for name in block_to_names[bid].tolist()
+        ]
+        train_names = [
+            name
+            for f in range(n_splits)
+            if f != fold
+            for bid in fold_block_ids[f]
+            for name in block_to_names[bid].tolist()
+        ]
+        splits[f"fold_{fold}"] = {"train": train_names, "val": val_names}
+        log.info(
+            f"  Fold {fold}: {len(train_names)} train locations, {len(val_names)} val locations "
+            f"({fold_samples[fold]} samples)"
+        )
+
+    if save_path:
+        save_path = Path(save_path)
+        save_path.parent.mkdir(parents=True, exist_ok=True)
+        torch.save(splits, save_path)
+        log.info(f"Saved spatial splits to {save_path}")
+
+    return splits
+
+
+# ---------------------------------------------------------------------------
+# Main pipeline
+# ---------------------------------------------------------------------------
+
+
+def main(
+    source_csv: str,
+    out_csv: str,
+    out_parquet: str | None = None,
+    spatial_splits: bool = False,
+    countries: List[str] | None = None,
+    years: List[int] | None = None,
+    exclude_countries: List[str] | None = None,
+    exclude_years: List[int] | None = None,
+) -> pd.DataFrame:
+    """Preprocessing workflow for the crop yield Africa dataset."""
+    data_path = Path(source_csv)
+    out_csv_path = Path(out_csv)
+    data_dir = out_csv_path.parent
+
+    scaler_path = data_dir / f"fitted_scaler_{MODEL_READY_DATA_NAME}.pkl"
+    encoders_path = data_dir / f"label_encoders_{MODEL_READY_DATA_NAME}.pkl"
+    spatial_split_path = (
+        data_dir
+        / "splits"
+        / (
+            f"split_spatial_{SPATIAL_SPLIT_N_SPLITS}_folds_with_"
+            f"{SPATIAL_SPLIT_BLOCK_SIZE_KM}km_blocks_{MODEL_READY_DATA_NAME}.pth"
+        )
+    )
+
+    log.info("Starting preprocessing pipeline...")
+    log.info(f"Input: {data_path}")
+
+    # Load raw data
+    raw_df = pd.read_csv(data_path)
+    n_raw = len(raw_df)
+    log.info(f"Loaded {n_raw} rows from {data_path}")
+
+    # Filter by country and year before any other processing
+    df = raw_df.copy()
+    if countries is not None:
+        before = len(df)
+        df = df[df["Country"].isin(countries)].copy()
+        log.info(
+            f"Country filter ({', '.join(sorted(countries))}): "
+            f"kept {len(df)}, excluded {before - len(df)}"
+        )
+    if years is not None:
+        before = len(df)
+        df = df[df["Year"].isin(years)].copy()
+        log.info(
+            f"Year filter ({', '.join(str(y) for y in sorted(years))}): "
+            f"kept {len(df)}, excluded {before - len(df)}"
+        )
+    if exclude_countries is not None:
+        before = len(df)
+        df = df[~df["Country"].isin(exclude_countries)].copy()
+        log.info(
+            f"Exclude countries ({', '.join(sorted(exclude_countries))}): "
+            f"kept {len(df)}, excluded {before - len(df)}"
+        )
+    if exclude_years is not None:
+        before = len(df)
+        df = df[~df["Year"].isin(exclude_years)].copy()
+        log.info(
+            f"Exclude years ({', '.join(str(y) for y in sorted(exclude_years))}): "
+            f"kept {len(df)}, excluded {before - len(df)}"
+        )
+    n_after_filter = len(df)
+
+    # Determine train mask on the filtered data
+    train_mask = df["Country"].isin(TRAIN_COUNTRIES)
+    log.info(
+        f"Train mask: {train_mask.sum()} rows ({', '.join(TRAIN_COUNTRIES)}) out of {n_after_filter} total"
+    )
+
+    # Compute derived features
+    log.info("Computing derived features...")
+    df = compute_derived_features(df)
+
+    # Remove yield outliers
+    log.info("Removing yield outliers...")
+    df, outlier_mask = remove_yield_outliers(df, TARGET_COLUMNS[0], iqr_multiplier=3.0)
+    # Re-align train_mask after outlier removal
+    train_mask = train_mask[df.index]
+
+    # Apply log transforms
+    log.info("Applying log transforms...")
+    df = apply_log_transforms(df, LOG_TRANSFORM_FEATURES)
+
+    train_df = df[train_mask]
+    log.info(f"Training set size: {len(train_df)} samples")
+
+    # Fit transformers on train split only
+    log.info("Fitting StandardScaler on train split...")
+    scaler = fit_scaler(train_df, CONTINUOUS_FEATURES)
+
+    log.info("Fitting LabelEncoders on train split...")
+    all_categorical = TABULAR_CATEGORICAL_FEATURES + AUX_FEATURES
+    encoders = fit_label_encoders(train_df, all_categorical)
+
+    # Apply transformations to full dataset
+    log.info("Applying transformations to full dataset...")
+    df = apply_scaler(df, scaler, CONTINUOUS_FEATURES)
+    df = apply_label_encoders(df, encoders, all_categorical)
+
+    # Save transformers
+    scaler_path.parent.mkdir(parents=True, exist_ok=True)
+    joblib.dump(scaler, scaler_path)
+    log.info(f"Saved scaler to {scaler_path}")
+
+    encoders_path.parent.mkdir(parents=True, exist_ok=True)
+    joblib.dump(encoders, encoders_path)
+    log.info(f"Saved encoders to {encoders_path}")
+
+    # Validation checks
+    log.info("Validation checks:")
+    derived_cols = ["CN_ratio", "C_layer_delta", "BD_layer_delta", "WHC_proxy", "aridity_index"]
+    for col in derived_cols:
+        if col in df.columns:
+            n_nan = df[col].isna().sum()
+            n_inf = np.isinf(df[col]).sum()
+            if n_nan > 0 or n_inf > 0:
+                warnings.warn(f"  {col}: {n_nan} NaN, {n_inf} Inf values")
+            else:
+                log.info(f"  {col}: no NaN or Inf")
+
+    for col in all_categorical:
+        if col in df.columns and col in encoders:
+            n_classes = len(encoders[col].classes_)
+            min_val = df[col].min()
+            max_val = df[col].max()
+            if min_val < 0 or max_val >= n_classes:
+                warnings.warn(
+                    f"  {col}: indices [{min_val}, {max_val}] out of range [0, {n_classes-1}]"
+                )
+
+    # Apply canonical column rename (feat_/aux_/target_ prefixes, lowercase meta)
+    rename_map = build_column_rename_map(
+        continuous_features=CONTINUOUS_FEATURES,
+        tabular_categorical_features=TABULAR_CATEGORICAL_FEATURES,
+        aux_features=AUX_FEATURES,
+        target_columns=TARGET_COLUMNS,
+        name_loc_column=NAME_LOC_COLUMN,
+        metadata_columns=METADATA_COLUMNS,
+    )
+    df = df.rename(columns=rename_map)
+
+    # Prefix name_loc IDs with country name
+    if "name_loc" in df.columns and "country" in df.columns:
+        df["name_loc"] = df["country"].astype(str).str.upper() + "_" + df["name_loc"].astype(str)
+        log.info("Prefixed name_loc IDs with country names")
+        n_duplicates = df["name_loc"].duplicated().sum()
+        if n_duplicates > 0:
+            warnings.warn(f"Found {n_duplicates} duplicate name_loc IDs after prefixing")
+        else:
+            log.info(f"  No duplicates in name_loc ({df['name_loc'].nunique()} unique IDs)")
+
+    # Convert location_accuracy from text to numerical values
+    if "location_accuracy" in df.columns:
+        accuracy_map = {
+            "high location accuracy": 1,
+            "medium location accuracy": 2,
+            "low location accuracy": 3,
+        }
+        df["location_accuracy"] = df["location_accuracy"].str.lower().map(accuracy_map)
+
+    # Keep scaler metadata in sync with new column names
+    if hasattr(scaler, "feature_names_in_") and scaler.feature_names_in_ is not None:
+        scaler.feature_names_in_ = np.array(
+            [rename_map.get(n, n) for n in scaler.feature_names_in_]
+        )
+    encoders = {rename_map.get(k, k): v for k, v in encoders.items()}
+
+    # Calculate and save spatial splits (optional)
+    if spatial_splits:
+        calculate_spatial_splits(
+            df=df,
+            block_size_km=SPATIAL_SPLIT_BLOCK_SIZE_KM,
+            n_splits=SPATIAL_SPLIT_N_SPLITS,
+            save_path=spatial_split_path,
+        )
+    else:
+        log.info("Skipping spatial split calculation (use --spatial_splits to enable)")
+
+    # Save outputs
+    out_csv_path.parent.mkdir(parents=True, exist_ok=True)
+    df.to_csv(out_csv_path, index=False, float_format="%.7f")
+    log.info(f"Saved CSV to {out_csv_path}")
+
+    if out_parquet is not None:
+        out_parquet_path = Path(out_parquet)
+        out_parquet_path.parent.mkdir(parents=True, exist_ok=True)
+        df.to_parquet(out_parquet_path, index=False)
+        log.info(f"Saved Parquet to {out_parquet_path}")
+
+    log.info("=== Summary ===")
+    log.info(f"  Raw rows loaded: {n_raw}")
+    log.info(f"  Rows excluded by country/year filter: {n_raw - n_after_filter}")
+    log.info(f"  Rows in output: {len(df)}")
+    log.info(f"  Continuous features: {len(CONTINUOUS_FEATURES)}")
+    log.info(f"  Tabular categorical features (feat_): {len(TABULAR_CATEGORICAL_FEATURES)}")
+    log.info(f"  Aux/caption features (aux_): {len(AUX_FEATURES)}")
+    log.info(
+        f"  Yield range: {df['target_yld_ton_ha'].min():.2f} - {df['target_yld_ton_ha'].max():.2f} t/ha"
+    )
+    log.info(f"  Mean yield: {df['target_yld_ton_ha'].mean():.2f} t/ha")
+    log.info("  Records per country and year:")
+    counts = df.groupby(["country", "year"]).size().unstack(fill_value=0)
+    for country, row in counts.iterrows():
+        year_counts = [f"{year}: {count}" for year, count in row.items() if count > 0]
+        log.info(f"    {country}: {', '.join(year_counts)}")
+
+    return df
+
+
+if __name__ == "__main__":
+    logging.basicConfig(
+        level=logging.INFO, format="%(asctime)s - %(name)s - %(levelname)s - %(message)s"
+    )
+
+    ap = argparse.ArgumentParser(
+        description="Build model-ready CSV/Parquet for the crop yield Africa use case."
+    )
+    ap.add_argument(
+        "--source_csv",
+        required=True,
+        help="Path to the raw input CSV (e.g. data/yield_africa/yield_africa_v20260218.csv)",
+    )
+    ap.add_argument(
+        "--out_csv",
+        required=True,
+        help="Path for the output model-ready CSV (e.g. data/yield_africa/model_ready_yield-africa.csv)",
+    )
+    ap.add_argument(
+        "--out_parquet",
+        default=None,
+        help="Optional path for an additional Parquet output.",
+    )
+    ap.add_argument(
+        "--spatial_splits",
+        action="store_true",
+        default=False,
+        help="Calculate and save spatial cross-validation splits (default: off).",
+    )
+    ap.add_argument(
+        "--countries",
+        nargs="+",
+        default=None,
+        metavar="CODE",
+        help="Country codes to include (e.g. --countries ETH KEN TAN). Default: all countries.",
+    )
+    ap.add_argument(
+        "--years",
+        nargs="+",
+        type=int,
+        default=None,
+        metavar="YEAR",
+        help="Years to include (e.g. --years 2018 2019 2020). Default: all years.",
+    )
+    ap.add_argument(
+        "--exclude_countries",
+        nargs="+",
+        default=None,
+        metavar="CODE",
+        help="Country codes to exclude (e.g. --exclude_countries MOZ ZIM).",
+    )
+    ap.add_argument(
+        "--exclude_years",
+        nargs="+",
+        type=int,
+        default=None,
+        metavar="YEAR",
+        help="Years to exclude (e.g. --exclude_years 2015 2016).",
+    )
+    args = ap.parse_args()
+    main(
+        args.source_csv,
+        args.out_csv,
+        args.out_parquet,
+        args.spatial_splits,
+        args.countries,
+        args.years,
+        args.exclude_countries,
+        args.exclude_years,
+    )

--- a/src/data_preprocessing/tessera_embeds.py
+++ b/src/data_preprocessing/tessera_embeds.py
@@ -1,7 +1,11 @@
 import math
 import os
+import threading
 
 import numpy as np
+
+# Serialises concurrent reads/writes to the per-directory meta.csv log file.
+_meta_csv_lock = threading.Lock()
 import pandas as pd
 import rasterio
 from geotessera import GeoTessera
@@ -122,6 +126,12 @@ def get_tessera_embeds(
         if reproject_memfile:
             memfiles.append(reproject_memfile)
 
+    if not tiles:
+        print(f"No TESSERA tiles found for {name_loc} at ({lon:.4f}, {lat:.4f}) year={year}. Skipping.")
+        for mf in memfiles:
+            mf.close()
+        return
+
     mosaic, mosaic_transform = merge(tiles)
     mosaic = mosaic.transpose(1, 2, 0)
 
@@ -134,10 +144,17 @@ def get_tessera_embeds(
     col, row = crs_to_pixel_coords(lon_utm, lat_utm, mosaic_transform)
     half = tile_size // 2
     row_min = row - half
-    row_max = row + half
+    row_max = row + tile_size - half  # tile_size - half ensures correct size for odd tile_size
     col_min = col - half
-    col_max = col + half
+    col_max = col + tile_size - half
     crop = mosaic[row_min:row_max, col_min:col_max, :]
+
+    if crop.shape[0] != tile_size or crop.shape[1] != tile_size:
+        print(
+            f"Unexpected crop shape {crop.shape} for {name_loc} "
+            f"(expected {tile_size}x{tile_size}). Skipping."
+        )
+        return
 
     # Save array
     os.makedirs(save_dir, exist_ok=True)
@@ -151,11 +168,14 @@ def get_tessera_embeds(
 
     meta_file = f"{save_dir}/meta.csv"
 
-    if os.path.exists(meta_file):
-        meta_df = pd.concat([meta_df, pd.read_csv(meta_file)], ignore_index=True)
-
-    meta_df.to_csv(meta_file, index=False)
-    print(f"Meta data logged to {meta_file}")
+    with _meta_csv_lock:
+        try:
+            if os.path.exists(meta_file):
+                meta_df = pd.concat([meta_df, pd.read_csv(meta_file)], ignore_index=True)
+            meta_df.to_csv(meta_file, index=False)
+            print(f"Meta data logged to {meta_file}")
+        except Exception as e:
+            print(f"Warning: could not update meta.csv ({e}). Tile was saved successfully.")
 
 
 def tessera_from_df(

--- a/src/data_preprocessing/yield_africa_loco_splits.py
+++ b/src/data_preprocessing/yield_africa_loco_splits.py
@@ -1,0 +1,171 @@
+"""Generate leave-one-country-out (LOCO) split files for the yield_africa dataset.
+
+Location: src/data_preprocessing/yield_africa_loco_splits.py
+
+For each held-out country one `.pth` file is written to
+`{data_dir}/yield_africa/splits/split_loco_{COUNTRY}.pth`.
+
+Split layout
+------------
+- test  : all records from the held-out country
+- train : 80 % of records from the remaining countries (random, seeded)
+- val   : 20 % of records from the remaining countries (random, seeded)
+
+The files are consumed by BaseDataModule when `split_mode: from_file` and
+`saved_split_file_name: split_loco_{COUNTRY}.pth`.
+
+Usage
+-----
+    python src/data_preprocessing/yield_africa_loco_splits.py --data_dir data/
+    python src/data_preprocessing/yield_africa_loco_splits.py --data_dir data/ --country KEN
+"""
+
+import argparse
+import logging
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+import torch
+
+log = logging.getLogger(__name__)
+
+# All countries present in the full dataset (must match _ALL_COUNTRIES in
+# yield_africa_dataset.py so that the feature encoding is consistent).
+ALL_COUNTRIES = ["BF", "BUR", "ETH", "KEN", "MAL", "RWA", "TAN", "ZAM"]
+
+DATASET_NAME = "yield_africa"
+MODEL_READY_CSV = f"model_ready_{DATASET_NAME}.csv"
+
+
+def make_loco_split(
+    df: pd.DataFrame,
+    test_country: str,
+    val_fraction: float = 0.2,
+    seed: int = 12345,
+) -> dict:
+    """Return a split-indices dict for one held-out country.
+
+    :param df: full model-ready dataframe (must contain 'country' and 'name_loc')
+    :param test_country: country code to hold out as the test set
+    :param val_fraction: fraction of the non-test pool to use for validation
+    :param seed: random seed for the train/val shuffle
+    :return: dict with 'train_indices', 'val_indices', 'test_indices' as pd.Series of name_locs
+    """
+    test_mask = df["country"] == test_country
+    test_locs = df.loc[test_mask, "name_loc"].reset_index(drop=True)
+
+    remaining = df.loc[~test_mask, "name_loc"].reset_index(drop=True)
+    rng = np.random.default_rng(seed)
+    shuffled = remaining.sample(frac=1, random_state=seed).reset_index(drop=True)
+    n_val = int(len(shuffled) * val_fraction)
+    val_locs = shuffled.iloc[:n_val]
+    train_locs = shuffled.iloc[n_val:]
+
+    return {
+        "train_indices": train_locs,
+        "val_indices": val_locs,
+        "test_indices": test_locs,
+    }
+
+
+def generate_splits(
+    data_dir: str,
+    countries: list[str] | None = None,
+    val_fraction: float = 0.2,
+    seed: int = 12345,
+) -> None:
+    """Generate and save LOCO split files for the requested countries.
+
+    :param data_dir: root data directory (same as `paths.data_dir` in configs)
+    :param countries: list of country codes to generate splits for; None means all
+    :param val_fraction: fraction of non-test data to use for validation
+    :param seed: random seed
+    """
+    dataset_dir = Path(data_dir) / DATASET_NAME
+    csv_path = dataset_dir / MODEL_READY_CSV
+    splits_dir = dataset_dir / "splits"
+
+    if not csv_path.exists():
+        raise FileNotFoundError(f"Model-ready CSV not found: {csv_path}")
+
+    splits_dir.mkdir(parents=True, exist_ok=True)
+
+    df = pd.read_csv(csv_path)
+    if "country" not in df.columns or "name_loc" not in df.columns:
+        raise ValueError("CSV must contain 'country' and 'name_loc' columns")
+
+    available = sorted(df["country"].unique().tolist())
+    targets = countries if countries is not None else available
+
+    for country in targets:
+        if country not in available:
+            log.warning(f"Country '{country}' not found in CSV (available: {available}), skipping")
+            continue
+
+        split = make_loco_split(df, country, val_fraction=val_fraction, seed=seed)
+        n_train = len(split["train_indices"])
+        n_val = len(split["val_indices"])
+        n_test = len(split["test_indices"])
+
+        out_path = splits_dir / f"split_loco_{country}.pth"
+        torch.save(split, out_path)
+
+        log.info(
+            f"  {country}: train={n_train}, val={n_val}, test={n_test} "
+            f"-> {out_path.name}"
+        )
+        print(
+            f"  Saved split_loco_{country}.pth  "
+            f"(train={n_train}, val={n_val}, test={n_test})"
+        )
+
+
+def main() -> None:
+    logging.basicConfig(level=logging.INFO, format="%(message)s")
+
+    parser = argparse.ArgumentParser(
+        description="Generate leave-one-country-out split files for yield_africa."
+    )
+    parser.add_argument(
+        "--data_dir",
+        type=str,
+        default="data/",
+        help="Root data directory (same as paths.data_dir in configs). Default: data/",
+    )
+    parser.add_argument(
+        "--country",
+        type=str,
+        default=None,
+        help="Single country code to generate a split for. Omit to generate all.",
+    )
+    parser.add_argument(
+        "--val_fraction",
+        type=float,
+        default=0.2,
+        help="Fraction of non-test records used for validation. Default: 0.2",
+    )
+    parser.add_argument(
+        "--seed",
+        type=int,
+        default=12345,
+        help="Random seed for the train/val shuffle. Default: 12345",
+    )
+    args = parser.parse_args()
+
+    countries = [args.country] if args.country else None
+    print(
+        f"Generating LOCO splits  data_dir={args.data_dir}  "
+        f"countries={countries or 'all'}  val_fraction={args.val_fraction}  seed={args.seed}"
+    )
+    generate_splits(
+        data_dir=args.data_dir,
+        countries=countries,
+        val_fraction=args.val_fraction,
+        seed=args.seed,
+    )
+    print("Done.")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/data_preprocessing/yield_africa_tessera_preprocess.py
+++ b/src/data_preprocessing/yield_africa_tessera_preprocess.py
@@ -65,7 +65,6 @@ def fetch_tessera_tiles(
     countries: list[str] | None = None,
     years: list[int] | None = None,
     cache_dir: str | None = None,
-    embeddings_dir: str | None = None,
     workers: int = 2,
 ) -> None:
     """Fetch TESSERA tiles for every record in the yield_africa CSV.
@@ -74,13 +73,12 @@ def fetch_tessera_tiles(
     :param tile_size: spatial extent of each tile in pixels
     :param countries: optional list of country codes to restrict fetching
     :param years: optional list of years to restrict fetching
-    :param cache_dir: directory for GeoTessera's internal registry cache;
-        defaults to ``{data_dir}/cache/tessera``
-    :param embeddings_dir: directory where GeoTessera stores the raw downloaded
-        embedding tiles (``global_0.1_degree_representation/`` etc.).  Defaults
-        to the current working directory when not set, which can silently fill
-        the project folder with tens of GB of data.  Point this at an external
-        drive when disk space is limited.
+    :param cache_dir: base directory for all TESSERA cache files.  GeoTessera's
+        internal registry is stored here; the large raw downloaded source tiles
+        (``global_0.1_degree_representation/`` etc.) are kept in the ``raw/``
+        subfolder.  Defaults to the ``TESSERA_EMBEDDINGS_DIR`` env var when set,
+        otherwise ``{data_dir}/cache/tessera``.  Point this at an external drive
+        when disk space is limited.
     :param workers: number of parallel download threads.  Each thread keeps its
         own GeoTessera instance to avoid shared state.  Default: 2 (external
         drive I/O is usually the bottleneck; more workers add contention).
@@ -95,7 +93,9 @@ def fetch_tessera_tiles(
     save_dir.mkdir(parents=True, exist_ok=True)
 
     if cache_dir is None:
-        cache_dir = str(Path(data_dir) / "cache" / "tessera")
+        cache_dir = os.environ.get("TESSERA_EMBEDDINGS_DIR") or str(Path(data_dir) / "cache" / "tessera")
+
+    embeddings_dir = str(Path(cache_dir) / "raw")
 
     df = pd.read_csv(csv_path)
 
@@ -116,7 +116,9 @@ def fetch_tessera_tiles(
 
     print(
         f"Records: {n_total} total, {n_existing} already cached, "
-        f"{n_to_fetch} to fetch  (tile_size={tile_size}, workers={workers})"
+        f"{n_to_fetch} to fetch  (tile_size={tile_size}, workers={workers})\n"
+        f"  cache_dir    : {cache_dir}\n"
+        f"  embeddings_dir: {embeddings_dir}"
     )
 
     # Build GeoTessera constructor kwargs shared across all threads.
@@ -130,8 +132,7 @@ def fetch_tessera_tiles(
         # noticeable CPU time per tile and making progress look stalled.
         "verify_hashes": False,
     }
-    if embeddings_dir is not None:
-        _gt_kwargs["embeddings_dir"] = embeddings_dir
+    _gt_kwargs["embeddings_dir"] = embeddings_dir
 
     _thread_local = threading.local()
 
@@ -243,25 +244,24 @@ def main() -> None:
         "--cache_dir",
         type=str,
         default=None,
-        help="GeoTessera internal registry cache directory. Default: {data_dir}/cache/tessera",
-    )
-    parser.add_argument(
-        "--embeddings_dir",
-        type=str,
-        default=os.environ.get("TESSERA_EMBEDDINGS_DIR"),
         help=(
-            "Directory for GeoTessera raw source tiles "
-            "(global_0.1_degree_representation/ etc.). "
-            "Falls back to the TESSERA_EMBEDDINGS_DIR env var, then the current "
-            "working directory. Set TESSERA_EMBEDDINGS_DIR in .env to avoid "
-            "passing this flag every run."
+            "Base directory for all TESSERA cache files. "
+            "GeoTessera's registry is stored here; large raw source tiles go in "
+            "the raw/ subfolder. "
+            "Falls back to the TESSERA_EMBEDDINGS_DIR env var, then "
+            "{data_dir}/cache/tessera. Set TESSERA_EMBEDDINGS_DIR in .env to "
+            "avoid passing this flag every run."
         ),
     )
     parser.add_argument(
         "--workers",
         type=int,
         default=2,
-        help="Number of parallel download threads. Default: 2",
+        help=(
+            "Number of parallel download threads. Default: 2. "
+            "When writing to an external drive too many workers can cause I/O "
+            "bottlenecks. Reduce the number of workers to improve throughput."
+        ),
     )
     args = parser.parse_args()
 
@@ -276,7 +276,6 @@ def main() -> None:
         countries=args.countries,
         years=args.years,
         cache_dir=args.cache_dir,
-        embeddings_dir=args.embeddings_dir,
         workers=args.workers,
     )
 

--- a/src/data_preprocessing/yield_africa_tessera_preprocess.py
+++ b/src/data_preprocessing/yield_africa_tessera_preprocess.py
@@ -1,0 +1,285 @@
+"""Fetch and cache TESSERA embedding tiles for the yield_africa dataset.
+
+Location: src/data_preprocessing/yield_africa_tessera_preprocess.py
+
+Tiles are saved as NumPy arrays to:
+    {data_dir}/yield_africa/eo/tessera/tessera_{name_loc}.npy
+
+This matches the path built by BaseDataset.add_modality_paths_to_df() and
+loaded by BaseDataset.setup_tessera() at training time.
+
+Unlike tessera_from_df() (which takes a single fixed year), this script
+uses each record's own `year` column so that per-record inter-annual
+phenology is captured — the key signal missing from the static tabular
+features.
+
+The script is resumable: get_tessera_embeds() skips files that already
+exist, so interrupted runs can be continued safely.
+
+Usage
+-----
+    # All records
+    python src/data_preprocessing/yield_africa_tessera_preprocess.py \\
+        --data_dir data/
+
+    # Single country, useful for incremental fetching
+    python src/data_preprocessing/yield_africa_tessera_preprocess.py \\
+        --data_dir data/ --countries KEN RWA
+
+    # Smaller tile size (faster, less context)
+    python src/data_preprocessing/yield_africa_tessera_preprocess.py \\
+        --data_dir data/ --tile_size 5
+"""
+
+import argparse
+import logging
+import os
+import socket
+import sys
+import threading
+from concurrent.futures import FIRST_COMPLETED, ThreadPoolExecutor, wait
+from pathlib import Path
+
+# Ensure the project root is on sys.path when the script is run directly.
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+import pandas as pd
+from geotessera import GeoTessera
+
+from src.data_preprocessing.tessera_embeds import get_tessera_embeds
+
+log = logging.getLogger(__name__)
+
+DATASET_NAME = "yield_africa"
+MODEL_READY_CSV = f"model_ready_{DATASET_NAME}.csv"
+
+# Tile size in pixels.  A small tile (e.g. 9) captures local context around
+# each plot point without pulling in large surrounding areas.  Consistent
+# with the typical smallholder farm size in the region.
+DEFAULT_TILE_SIZE = 9
+
+
+def fetch_tessera_tiles(
+    data_dir: str,
+    tile_size: int = DEFAULT_TILE_SIZE,
+    countries: list[str] | None = None,
+    years: list[int] | None = None,
+    cache_dir: str | None = None,
+    embeddings_dir: str | None = None,
+    workers: int = 2,
+) -> None:
+    """Fetch TESSERA tiles for every record in the yield_africa CSV.
+
+    :param data_dir: root data directory (same as ``paths.data_dir`` in configs)
+    :param tile_size: spatial extent of each tile in pixels
+    :param countries: optional list of country codes to restrict fetching
+    :param years: optional list of years to restrict fetching
+    :param cache_dir: directory for GeoTessera's internal registry cache;
+        defaults to ``{data_dir}/cache/tessera``
+    :param embeddings_dir: directory where GeoTessera stores the raw downloaded
+        embedding tiles (``global_0.1_degree_representation/`` etc.).  Defaults
+        to the current working directory when not set, which can silently fill
+        the project folder with tens of GB of data.  Point this at an external
+        drive when disk space is limited.
+    :param workers: number of parallel download threads.  Each thread keeps its
+        own GeoTessera instance to avoid shared state.  Default: 2 (external
+        drive I/O is usually the bottleneck; more workers add contention).
+    """
+    dataset_dir = Path(data_dir) / DATASET_NAME
+    csv_path = dataset_dir / MODEL_READY_CSV
+    save_dir = dataset_dir / "eo" / "tessera"
+
+    if not csv_path.exists():
+        raise FileNotFoundError(f"Model-ready CSV not found: {csv_path}")
+
+    save_dir.mkdir(parents=True, exist_ok=True)
+
+    if cache_dir is None:
+        cache_dir = str(Path(data_dir) / "cache" / "tessera")
+
+    df = pd.read_csv(csv_path)
+
+    # Optional filters (consistent with YieldAfricaDataset filter params)
+    if countries is not None:
+        df = df[df["country"].isin(countries)]
+        log.info(f"Filtered to countries {countries}: {len(df)} records")
+    if years is not None:
+        df = df[df["year"].isin(years)]
+        log.info(f"Filtered to years {years}: {len(df)} records")
+
+    n_total = len(df)
+    n_existing = sum(
+        1 for _, row in df.iterrows()
+        if (save_dir / f"tessera_{row.name_loc}.npy").exists()
+    )
+    n_to_fetch = n_total - n_existing
+
+    print(
+        f"Records: {n_total} total, {n_existing} already cached, "
+        f"{n_to_fetch} to fetch  (tile_size={tile_size}, workers={workers})"
+    )
+
+    # Build GeoTessera constructor kwargs shared across all threads.
+    # Each thread creates its own instance (thread-local) to avoid sharing
+    # internal state such as open file handles and rasterio MemoryFiles.
+    _default_registry_dir = Path.home() / ".cache" / "geotessera"
+    _use_local_registry = (_default_registry_dir / "registry.parquet").exists()
+    _gt_kwargs: dict = {
+        # Skip SHA-256 hash verification after each tile download.  Verification
+        # reads the entire (potentially large) file again after download, adding
+        # noticeable CPU time per tile and making progress look stalled.
+        "verify_hashes": False,
+    }
+    if embeddings_dir is not None:
+        _gt_kwargs["embeddings_dir"] = embeddings_dir
+
+    _thread_local = threading.local()
+
+    def _get_gt() -> GeoTessera:
+        """Return a thread-local GeoTessera instance, creating it on first use."""
+        if not hasattr(_thread_local, "gt"):
+            if _use_local_registry:
+                _thread_local.gt = GeoTessera(registry_dir=_default_registry_dir, **_gt_kwargs)
+            else:
+                _thread_local.gt = GeoTessera(cache_dir=cache_dir, **_gt_kwargs)
+        return _thread_local.gt
+
+    def _fetch_one(row) -> str:
+        get_tessera_embeds(
+            lon=row.lon,
+            lat=row.lat,
+            name_loc=row.name_loc,
+            year=int(row.year),
+            save_dir=str(save_dir),
+            tile_size=tile_size,
+            tessera_con=_get_gt(),
+        )
+        return row.name_loc
+
+    # Bound all socket operations (urllib HTTP requests inside geotessera).
+    # Without this, a stalled connection blocks the thread until the OS TCP
+    # keepalive fires, which can take many minutes.
+    SOCKET_TIMEOUT = 60   # seconds per socket operation
+    HEARTBEAT = 30        # print a heartbeat when no future completes this fast
+    TILE_TIMEOUT = 600    # give up warning after 10 min of complete silence
+    socket.setdefaulttimeout(SOCKET_TIMEOUT)
+
+    rows = [row for _, row in df.iterrows()]
+    done = 0
+    pending: set = set()
+    silent_seconds = 0
+
+    try:
+        with ThreadPoolExecutor(max_workers=workers) as pool:
+            # Submit all jobs up-front; the pool queues them internally.
+            futures = {pool.submit(_fetch_one, row): row.name_loc for row in rows}
+            pending = set(futures)
+
+            while pending:
+                finished, pending = wait(pending, timeout=HEARTBEAT, return_when=FIRST_COMPLETED)
+
+                if not finished:
+                    silent_seconds += HEARTBEAT
+                    print(
+                        f"  ... still working — {done}/{n_total} done, "
+                        f"{len(pending)} pending, {silent_seconds}s since last completion"
+                    )
+                    if silent_seconds >= TILE_TIMEOUT:
+                        print(f"  WARNING: no progress in {TILE_TIMEOUT}s, something may be stuck.")
+                    continue
+
+                silent_seconds = 0
+                for fut in finished:
+                    done += 1
+                    if done % 100 == 0 or done == n_total:
+                        print(f"  {done}/{n_total}")
+                    try:
+                        fut.result()
+                    except Exception as exc:
+                        print(f"  ERROR fetching {futures[fut]}: {exc}")
+
+    except KeyboardInterrupt:
+        print("\nInterrupted — cancelling queued futures (in-flight downloads will finish).")
+        for fut in pending:
+            fut.cancel()
+
+    print(f"Done. Tiles saved to: {save_dir}")
+
+
+def main() -> None:
+    logging.basicConfig(level=logging.INFO, format="%(message)s")
+
+    parser = argparse.ArgumentParser(
+        description="Fetch TESSERA embedding tiles for the yield_africa dataset."
+    )
+    parser.add_argument(
+        "--data_dir",
+        type=str,
+        default="data/",
+        help="Root data directory (same as paths.data_dir in configs). Default: data/",
+    )
+    parser.add_argument(
+        "--tile_size",
+        type=int,
+        default=DEFAULT_TILE_SIZE,
+        help=f"Tile size in pixels. Default: {DEFAULT_TILE_SIZE}",
+    )
+    parser.add_argument(
+        "--countries",
+        nargs="+",
+        default=None,
+        metavar="CODE",
+        help="Country codes to restrict fetching (e.g. KEN RWA). Default: all",
+    )
+    parser.add_argument(
+        "--years",
+        nargs="+",
+        type=int,
+        default=None,
+        metavar="YEAR",
+        help="Years to restrict fetching (e.g. 2019 2020). Default: all",
+    )
+    parser.add_argument(
+        "--cache_dir",
+        type=str,
+        default=None,
+        help="GeoTessera internal registry cache directory. Default: {data_dir}/cache/tessera",
+    )
+    parser.add_argument(
+        "--embeddings_dir",
+        type=str,
+        default=os.environ.get("TESSERA_EMBEDDINGS_DIR"),
+        help=(
+            "Directory for GeoTessera raw source tiles "
+            "(global_0.1_degree_representation/ etc.). "
+            "Falls back to the TESSERA_EMBEDDINGS_DIR env var, then the current "
+            "working directory. Set TESSERA_EMBEDDINGS_DIR in .env to avoid "
+            "passing this flag every run."
+        ),
+    )
+    parser.add_argument(
+        "--workers",
+        type=int,
+        default=2,
+        help="Number of parallel download threads. Default: 2",
+    )
+    args = parser.parse_args()
+
+    print(
+        f"Fetching TESSERA tiles  data_dir={args.data_dir}  "
+        f"tile_size={args.tile_size}  countries={args.countries or 'all'}  "
+        f"years={args.years or 'all'}"
+    )
+    fetch_tessera_tiles(
+        data_dir=args.data_dir,
+        tile_size=args.tile_size,
+        countries=args.countries,
+        years=args.years,
+        cache_dir=args.cache_dir,
+        embeddings_dir=args.embeddings_dir,
+        workers=args.workers,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/src/models/base_model.py
+++ b/src/models/base_model.py
@@ -61,9 +61,23 @@ class BaseModel(LightningModule, ABC):
                 # Freeze the rest
                 param.requires_grad = False
 
-        # Set module modes correctly
+        # Set module modes correctly.
+        # A module should be in train() if:
+        #   - it IS a trainable module (name == t), or
+        #   - it is a CHILD of a trainable module (name starts with t + "."), or
+        #   - it is an ANCESTOR of a trainable module (t starts with name + "."),
+        #     so that container modules reflect the correct mode, or
+        #   - it is the root module (""), which must be train when any child is.
+        def _in_train_scope(name: str) -> bool:
+            if not name:  # root module
+                return bool(self.trainable_modules)
+            for t in self.trainable_modules:
+                if name == t or name.startswith(t + ".") or t.startswith(name + "."):
+                    return True
+            return False
+
         for name, module in self.named_modules():
-            if any(t.startswith(name) for t in self.trainable_modules):
+            if _in_train_scope(name):
                 module.train()
             else:
                 module.eval()

--- a/src/models/base_model.py
+++ b/src/models/base_model.py
@@ -27,7 +27,7 @@ class BaseModel(LightningModule, ABC):
         """
         super().__init__()
         self.save_hyperparameters(
-            ignore=["loss_fn", "eo_encoder", "prediction_head", "text_encoder", "metrics"]
+            ignore=["loss_fn", "geo_encoder", "prediction_head", "text_encoder", "metrics"]
         )
 
         self.trainable_modules = trainable_modules

--- a/src/models/components/geo_encoders/average_encoder.py
+++ b/src/models/components/geo_encoders/average_encoder.py
@@ -4,36 +4,36 @@ import torch
 import torch.nn.functional as F
 from torch import nn
 
-from src.models.components.eo_encoders.base_eo_encoder import BaseEOEncoder
+from src.models.components.geo_encoders.base_geo_encoder import BaseGeoEncoder
 
 
-class AverageEncoder(BaseEOEncoder):
+class AverageEncoder(BaseGeoEncoder):
     def __init__(
         self,
         output_dim: int | None = None,
-        eo_data_name="aef",
+        geo_data_name="aef",
     ) -> None:
         super().__init__()
 
         dict_n_bands_default = {"s2": 4, "aef": 64, "tessera": 128}
-        self.allowed_eo_data_names: list[str] = list(dict_n_bands_default.keys())
+        self.allowed_geo_data_names: list[str] = list(dict_n_bands_default.keys())
 
         assert (
-            eo_data_name in dict_n_bands_default
-        ), f"eo_data_name must be one of {self.allowed_eo_data_names}, got {eo_data_name}"
-        self.eo_data_name = eo_data_name
+            geo_data_name in dict_n_bands_default
+        ), f"geo_data_name must be one of {self.allowed_geo_data_names}, got {geo_data_name}"
+        self.geo_data_name = geo_data_name
 
-        if output_dim is None or output_dim == dict_n_bands_default[eo_data_name]:
-            self.output_dim = dict_n_bands_default[eo_data_name]
+        if output_dim is None or output_dim == dict_n_bands_default[geo_data_name]:
+            self.output_dim = dict_n_bands_default[geo_data_name]
             self.extra_projector = None
-            self.eo_encoder = self._average
+            self.geo_encoder = self._average
         else:
             assert (
                 type(output_dim) is int and output_dim > 0
             ), f"output_dim must be positive int, got {output_dim}"
             self.output_dim = output_dim
-            self.extra_projector = nn.Linear(dict_n_bands_default[eo_data_name], output_dim)
-            self.eo_encoder = self._average_and_project
+            self.extra_projector = nn.Linear(dict_n_bands_default[geo_data_name], output_dim)
+            self.geo_encoder = self._average_and_project
 
     def _average(self, x: torch.Tensor) -> torch.Tensor:
         """Averages the input tensor over spatial dimensions.
@@ -59,11 +59,11 @@ class AverageEncoder(BaseEOEncoder):
         dtype = self.dtype
         if eo_data.dtype != dtype:
             eo_data = eo_data.to(dtype)
-        feats = self.eo_encoder(eo_data[self.eo_data_name])
+        feats = self.geo_encoder(eo_data[self.geo_data_name])
         # n_nans = torch.sum(torch.isnan(feats)).item()
         # assert (
         #     n_nans == 0
-        # ), f"AverageEncoder output contains {n_nans}/{feats.numel()} NaNs PRIOR to normalization with data min {eo_data[self.eo_data_name].min()} and max {eo_data[self.eo_data_name].max()}."
+        # ), f"AverageEncoder output contains {n_nans}/{feats.numel()} NaNs PRIOR to normalization with data min {eo_data[self.geo_data_name].min()} and max {eo_data[self.geo_data_name].max()}."
 
         return feats.to(dtype)
 

--- a/src/models/components/geo_encoders/average_encoder.py
+++ b/src/models/components/geo_encoders/average_encoder.py
@@ -55,16 +55,14 @@ class AverageEncoder(BaseGeoEncoder):
 
     @override
     def forward(self, batch: Dict[str, torch.Tensor]) -> torch.Tensor:
-        eo_data = batch.get("eo", {})
-        dtype = self.dtype
-        if eo_data.dtype != dtype:
-            eo_data = eo_data.to(dtype)
-        feats = self.geo_encoder(eo_data[self.geo_data_name])
-        # n_nans = torch.sum(torch.isnan(feats)).item()
-        # assert (
-        #     n_nans == 0
-        # ), f"AverageEncoder output contains {n_nans}/{feats.numel()} NaNs PRIOR to normalization with data min {eo_data[self.geo_data_name].min()} and max {eo_data[self.geo_data_name].max()}."
-
+        tile = batch.get("eo", {}).get(self.geo_data_name)
+        # Determine target dtype from parameters when available (e.g. when the
+        # optional projection layer exists); otherwise keep the input dtype.
+        params = list(self.parameters())
+        dtype = params[0].dtype if params else tile.dtype
+        if tile.dtype != dtype:
+            tile = tile.to(dtype)
+        feats = self.geo_encoder(tile)
         return feats.to(dtype)
 
 

--- a/src/models/components/geo_encoders/base_geo_encoder.py
+++ b/src/models/components/geo_encoders/base_geo_encoder.py
@@ -5,15 +5,15 @@ import torch
 from torch import nn
 
 
-class BaseEOEncoder(nn.Module, ABC):
+class BaseGeoEncoder(nn.Module, ABC):
     def __init__(self) -> None:
         super().__init__()
-        self.eo_encoder: nn.Module | None = None
+        self.geo_encoder: nn.Module | None = None
         self.output_dim: int | None = None
 
         # placeholders
-        self.allowed_eo_data_names: list[str] | None = None
-        self.eo_data_name: str | None = None
+        self.allowed_geo_data_names: list[str] | None = None
+        self.geo_data_name: str | None = None
 
     @abstractmethod
     def forward(self, batch: Dict[str, torch.Tensor]) -> torch.Tensor:
@@ -23,16 +23,16 @@ class BaseEOEncoder(nn.Module, ABC):
     def device(self) -> torch.device:
         devices = {p.device for p in self.parameters()}
         if len(devices) != 1:
-            raise RuntimeError("EO encoder is on multiple devices")
+            raise RuntimeError("GEO encoder is on multiple devices")
         return devices.pop()
 
     @property
     def dtype(self) -> torch.dtype:
         dtypes = {p.dtype for p in self.parameters()}
         if len(dtypes) != 1:
-            raise RuntimeError("EO encoder has multiple dtypes")
+            raise RuntimeError("GEO encoder has multiple dtypes")
         return dtypes.pop()
 
 
 if __name__ == "__main__":
-    _ = BaseEOEncoder(None)
+    _ = BaseGeoEncoder(None)

--- a/src/models/components/geo_encoders/cnn_encoder.py
+++ b/src/models/components/geo_encoders/cnn_encoder.py
@@ -5,10 +5,10 @@ import torchvision.models as models
 from torch import nn
 from torch.nn import functional as F
 
-from src.models.components.eo_encoders.base_eo_encoder import BaseEOEncoder
+from src.models.components.geo_encoders.base_geo_encoder import BaseGeoEncoder
 
 
-class CNNEncoder(BaseEOEncoder):
+class CNNEncoder(BaseGeoEncoder):
     """Convolutional neural network EO encoder. Adapted from PECL.
 
     :param backbone: backbone model to use (resnet)
@@ -25,7 +25,7 @@ class CNNEncoder(BaseEOEncoder):
         pretrained_cnn="imagenet",
         resnet_version=18,
         freezing_strategy="all",
-        eo_data_name="s2",
+        geo_data_name="s2",
         input_n_bands: int | None = None,
         output_dim=512,
     ) -> None:
@@ -36,9 +36,9 @@ class CNNEncoder(BaseEOEncoder):
         self.resnet_version = resnet_version
         self.freezing_strategy = freezing_strategy
 
-        self.allowed_eo_data_names = ["s2", "aef", "tessera"]
-        assert eo_data_name in self.allowed_eo_data_names
-        self.eo_data_name = eo_data_name
+        self.allowed_geo_data_names = ["s2", "aef", "tessera"]
+        assert geo_data_name in self.allowed_geo_data_names
+        self.geo_data_name = geo_data_name
 
         self.set_n_input_bands(input_n_bands)
         assert (
@@ -46,23 +46,23 @@ class CNNEncoder(BaseEOEncoder):
         ), f"input_n_bands must be int >=3, got {self.input_n_bands}"
         self.output_dim = output_dim
 
-        self.eo_encoder = self.get_backbone()
+        self.geo_encoder = self.get_backbone()
 
     def set_n_input_bands(self, n_bands: int | None = None) -> None:
-        """Sets number of input bands based on eo_data_name if n_bands is None.
+        """Sets number of input bands based on geo_data_name if n_bands is None.
 
         :param n_bands: number of input bands
         :return: None
         """
-        if n_bands is None:  # infer from eo_data_name
-            if self.eo_data_name == "s2":
+        if n_bands is None:  # infer from geo_data_name
+            if self.geo_data_name == "s2":
                 self.input_n_bands = 4
-            elif self.eo_data_name == "aef":
+            elif self.geo_data_name == "aef":
                 self.input_n_bands = 64
-            elif self.eo_data_name == "tessera":
+            elif self.geo_data_name == "tessera":
                 self.input_n_bands = 128
             print(
-                f"[CNNEncoder] Inferred input_n_bands={self.input_n_bands} for eo_data_name='{self.eo_data_name}'"
+                f"[CNNEncoder] Inferred input_n_bands={self.input_n_bands} for geo_data_name='{self.geo_data_name}'"
             )
         else:
             self.input_n_bands = n_bands
@@ -147,11 +147,11 @@ class CNNEncoder(BaseEOEncoder):
         dtype = self.dtype
         if eo_data.dtype != dtype:
             eo_data = eo_data.to(dtype)
-        feats = self.eo_encoder(eo_data[self.eo_data_name])
+        feats = self.geo_encoder(eo_data[self.geo_data_name])
         # n_nans = torch.sum(torch.isnan(feats)).item()
         # assert (
         #     n_nans == 0
-        # ), f"CNNEncoder output contains {n_nans}/{feats.numel()} NaNs PRIOR to normalization with data min {eo_data[self.eo_data_name].min()} and max {eo_data[self.eo_data_name].max()}."
+        # ), f"CNNEncoder output contains {n_nans}/{feats.numel()} NaNs PRIOR to normalization with data min {eo_data[self.geo_data_name].min()} and max {eo_data[self.geo_data_name].max()}."
 
         return feats.to(dtype)
 

--- a/src/models/components/geo_encoders/geoclip.py
+++ b/src/models/components/geo_encoders/geoclip.py
@@ -4,22 +4,22 @@ import torch
 from geoclip import LocationEncoder
 from torch.nn import functional as F
 
-from src.models.components.eo_encoders.base_eo_encoder import BaseEOEncoder
+from src.models.components.geo_encoders.base_geo_encoder import BaseGeoEncoder
 
 
-class GeoClipCoordinateEncoder(BaseEOEncoder):
+class GeoClipCoordinateEncoder(BaseGeoEncoder):
     def __init__(
         self,
-        eo_data_name="coords",
+        geo_data_name="coords",
     ) -> None:
         super().__init__()
-        self.eo_encoder = LocationEncoder()
-        self.output_dim = self.eo_encoder.LocEnc0.head[0].out_features
-        self.allowed_eo_data_names = ["coords"]
+        self.geo_encoder = LocationEncoder()
+        self.output_dim = self.geo_encoder.LocEnc0.head[0].out_features
+        self.allowed_geo_data_names = ["coords"]
         assert (
-            eo_data_name in self.allowed_eo_data_names
-        ), f"eo_data_name must be one of {self.allowed_eo_data_names}, got {eo_data_name}"
-        self.eo_data_name = eo_data_name
+            geo_data_name in self.allowed_geo_data_names
+        ), f"geo_data_name must be one of {self.allowed_geo_data_names}, got {geo_data_name}"
+        self.geo_data_name = geo_data_name
 
     @override
     def forward(
@@ -32,7 +32,7 @@ class GeoClipCoordinateEncoder(BaseEOEncoder):
         dtype = self.dtype
         if coords.dtype != dtype:
             coords = coords.to(dtype)
-        feats = self.eo_encoder(coords)
+        feats = self.geo_encoder(coords)
 
         return feats.to(dtype)
 

--- a/src/models/components/geo_encoders/multimodal_encoder.py
+++ b/src/models/components/geo_encoders/multimodal_encoder.py
@@ -1,8 +1,10 @@
 """Unified multimodal encoder for EO data.
 
 Controlled entirely via constructor flags:
-  - use_coords:   encode lat/lon with GeoClip
-  - use_tabular:  encode feat_* tabular columns
+  - use_coords:       activate the spatial/geo encoder branch
+  - use_tabular:      encode feat_* tabular columns
+  - geo_encoder_cfg:  pluggable geo encoder (any BaseGeoEncoder subclass);
+                      when None and use_coords=True, defaults to GeoClipCoordinateEncoder
 """
 
 from typing import Dict, override
@@ -16,9 +18,25 @@ from src.models.components.geo_encoders.geoclip import GeoClipCoordinateEncoder
 
 class MultiModalEncoder(BaseGeoEncoder):
     """
-    - coords only         (use_coords=True,  use_tabular=False)
-    - tabular only        (use_coords=False, use_tabular=True)
-    - coords + tabular    (use_coords=True,  use_tabular=True)
+    Modes (controlled by use_coords / use_tabular flags):
+
+      - geo only          (use_coords=True,  use_tabular=False)
+      - tabular only      (use_coords=False, use_tabular=True)
+      - geo + tabular     (use_coords=True,  use_tabular=True)
+
+    The geo encoder defaults to GeoClipCoordinateEncoder but can be replaced
+    with any BaseGeoEncoder via the geo_encoder_cfg parameter.  Hydra
+    instantiates geo_encoder_cfg before passing it here, so it arrives as a
+    ready-to-use nn.Module (e.g. AverageEncoder for TESSERA tiles).
+
+    Example config (TESSERA + tabular fusion):
+        geo_encoder:
+          _target_: ...MultiModalEncoder
+          use_coords: true
+          use_tabular: true
+          geo_encoder_cfg:
+            _target_: ...AverageEncoder
+            geo_data_name: tessera
     """
 
     def __init__(
@@ -26,7 +44,9 @@ class MultiModalEncoder(BaseGeoEncoder):
         use_coords: bool = True,
         use_tabular: bool = False,
         tab_embed_dim: int = 64,
+        tabular_dropout: float = 0.0,
         tabular_dim: int = None,
+        geo_encoder_cfg: BaseGeoEncoder | None = None,
     ) -> None:
         super().__init__()
 
@@ -35,12 +55,17 @@ class MultiModalEncoder(BaseGeoEncoder):
         self.use_coords = use_coords
         self.use_tabular = use_tabular
         self.tab_embed_dim = tab_embed_dim
+        self.tabular_dropout = tabular_dropout
         self._tabular_ready = False
+        self.fusion_norm = None  # set in build_tabular_branch when both branches active
 
         coords_dim = 0
         if use_coords:
-            self.coords_encoder = GeoClipCoordinateEncoder()
-            coords_dim = self.coords_encoder.output_dim  # 512
+            if geo_encoder_cfg is not None:
+                self.coords_encoder = geo_encoder_cfg
+            else:
+                self.coords_encoder = GeoClipCoordinateEncoder()
+            coords_dim = self.coords_encoder.output_dim
 
         self._coords_dim = coords_dim
 
@@ -57,19 +82,39 @@ class MultiModalEncoder(BaseGeoEncoder):
     # ------------------------------------------------------------------
 
     def build_tabular_branch(self, tabular_dim: int) -> None:
-        """Build (or rebuild) the tabular projection layer."""
+        """Build (or rebuild) the tabular projection MLP.
+
+        Architecture: LayerNorm → Linear(in, h) → ReLU → Dropout →
+                      Linear(h, h//2) → ReLU → Dropout → Linear(h//2, out)
+        where h = max(tab_embed_dim * 2, 128).
+        """
         if self._tabular_ready and hasattr(self, "_last_tabular_dim"):
             if self._last_tabular_dim == tabular_dim:
                 return  # already built with correct dim
 
+        hidden = max(self.tab_embed_dim * 2, 128)
+        drop = self.tabular_dropout
         self.tabular_proj = nn.Sequential(
             nn.LayerNorm(tabular_dim),
-            nn.Linear(tabular_dim, self.tab_embed_dim),
+            nn.Linear(tabular_dim, hidden),
             nn.ReLU(),
+            nn.Dropout(drop),
+            nn.Linear(hidden, hidden // 2),
+            nn.ReLU(),
+            nn.Dropout(drop),
+            nn.Linear(hidden // 2, self.tab_embed_dim),
         )
         self._last_tabular_dim = tabular_dim
         self._tabular_ready = True
         self.output_dim = self._coords_dim + self.tab_embed_dim
+
+        # Normalise the fused representation when both branches are active.
+        # The geo encoder output and the tabular projection may have different
+        # scales, so a LayerNorm stabilises training after concat.
+        if self.use_coords:
+            self.fusion_norm = nn.LayerNorm(self.output_dim)
+        else:
+            self.fusion_norm = None
 
     # ------------------------------------------------------------------
     # Forward
@@ -80,7 +125,7 @@ class MultiModalEncoder(BaseGeoEncoder):
         parts = []
 
         if self.use_coords:
-            parts.append(self.coords_encoder(batch))  # (B, 512)
+            parts.append(self.coords_encoder(batch))  # (B, coords_encoder.output_dim)
 
         if self.use_tabular:
             assert self._tabular_ready, (
@@ -90,4 +135,7 @@ class MultiModalEncoder(BaseGeoEncoder):
             tab = batch["eo"]["tabular"].float()  # (B, tabular_dim)
             parts.append(self.tabular_proj(tab))  # (B, tab_embed_dim)
 
-        return torch.cat(parts, dim=-1)
+        fused = torch.cat(parts, dim=-1)
+        if self.fusion_norm is not None:
+            fused = self.fusion_norm(fused)
+        return fused

--- a/src/models/components/geo_encoders/multimodal_encoder.py
+++ b/src/models/components/geo_encoders/multimodal_encoder.py
@@ -10,11 +10,11 @@ from typing import Dict, override
 import torch
 from torch import nn
 
-from src.models.components.eo_encoders.base_eo_encoder import BaseEOEncoder
-from src.models.components.eo_encoders.geoclip import GeoClipCoordinateEncoder
+from src.models.components.geo_encoders.base_geo_encoder import BaseGeoEncoder
+from src.models.components.geo_encoders.geoclip import GeoClipCoordinateEncoder
 
 
-class MultiModalEncoder(BaseEOEncoder):
+class MultiModalEncoder(BaseGeoEncoder):
     """
     - coords only         (use_coords=True,  use_tabular=False)
     - tabular only        (use_coords=False, use_tabular=True)

--- a/src/models/components/loss_fns/huber_loss.py
+++ b/src/models/components/loss_fns/huber_loss.py
@@ -1,0 +1,29 @@
+from typing import Dict, override
+
+import torch
+
+from src.models.components.loss_fns.base_loss_fn import BaseLossFn
+
+
+class HuberLoss(BaseLossFn):
+    def __init__(self) -> None:
+        super().__init__()
+        self.criterion = torch.nn.HuberLoss(delta=1.0, reduction="mean")
+        self.name = "huber_loss"
+
+    @override
+    def forward(
+        self,
+        pred: torch.Tensor,
+        labels: torch.Tensor | None = None,
+        batch: Dict[str, torch.Tensor] | None = None,
+        **kwargs,
+    ) -> torch.Tensor | Dict[str, torch.Tensor]:
+
+        labels = labels if labels is not None else batch.get("target")
+        huber_loss = self.criterion(pred, labels)
+
+        if "return_label" in kwargs:
+            return {self.name: huber_loss}
+        else:
+            return huber_loss

--- a/src/models/components/metrics/metrics_wrapper.py
+++ b/src/models/components/metrics/metrics_wrapper.py
@@ -10,7 +10,7 @@ from src.models.components.metrics.base_metrics import BaseMetrics
 class MetricsWrapper(nn.Module):
     def __init__(self, metrics: List[BaseMetrics | BaseLossFn]) -> None:
         super().__init__()
-        self.metrics = metrics
+        self.metrics = nn.ModuleList(metrics)
 
     def forward(self, mode="train", **kwargs) -> Dict[str, torch.float]:
         """Calculates all metrics and adds all the results into one dictionary for logging."""

--- a/src/models/components/metrics/r2.py
+++ b/src/models/components/metrics/r2.py
@@ -1,14 +1,29 @@
 from typing import Dict, override
 
 import torch
+from torch import nn
+from torchmetrics.regression import R2Score
 
 from src.models.components.metrics.base_metrics import BaseMetrics
 
+_MODES = ("train", "val", "test")
+
 
 class RSquared(BaseMetrics):
+    """Epoch-level R² using torchmetrics.R2Score.
+
+    A separate R2Score accumulator is kept per mode so that train, val, and
+    test statistics never mix.  Lightning detects the returned torchmetrics
+    Metric objects and calls .compute()/.reset() at epoch boundaries, giving
+    a correct epoch-wide R² instead of an average of per-batch R² values.
+    """
+
     def __init__(self) -> None:
         super().__init__()
         self.name = "r2"
+        # Keys are prefixed to avoid clashing with nn.Module attribute names
+        # (e.g. "train" conflicts with nn.Module.train()).
+        self._r2 = nn.ModuleDict({f"mode_{m}": R2Score() for m in _MODES})
 
     @override
     def forward(
@@ -17,12 +32,10 @@ class RSquared(BaseMetrics):
         labels: torch.Tensor | None = None,
         batch: Dict[str, torch.Tensor] | None = None,
         **kwargs,
-    ) -> torch.Tensor | Dict[str, torch.Tensor]:
-
+    ) -> Dict[str, torch.Tensor]:
         labels = labels if labels is not None else batch.get("target")
+        mode = kwargs.get("mode", "train")
 
-        ss_res = torch.sum((labels - pred) ** 2)
-        ss_tot = torch.sum((labels - torch.mean(labels)) ** 2) + 1e-12
-        r2 = 1.0 - ss_res / ss_tot
-
-        return {self.name: r2}
+        metric = self._r2[f"mode_{mode}"]
+        metric.update(pred.squeeze(-1), labels.squeeze(-1))
+        return {self.name: metric}

--- a/src/models/components/pred_heads/mlp_regression_head.py
+++ b/src/models/components/pred_heads/mlp_regression_head.py
@@ -19,10 +19,11 @@ from src.models.components.pred_heads.base_pred_head import BasePredictionHead
 class MLPRegressionPredictionHead(BasePredictionHead):
     """MLP prediction head for regression tasks (outputs a continuous value)."""
 
-    def __init__(self, nn_layers: int = 2, hidden_dim: int = 256) -> None:
+    def __init__(self, nn_layers: int = 2, hidden_dim: int = 256, dropout: float = 0.0) -> None:
         super().__init__()
         self.nn_layers = nn_layers
         self.hidden_dim = hidden_dim
+        self.dropout = dropout
 
     @override
     def forward(self, feats: torch.Tensor) -> torch.Tensor:
@@ -39,6 +40,8 @@ class MLPRegressionPredictionHead(BasePredictionHead):
         for _ in range(self.nn_layers - 1):
             layers.append(nn.Linear(in_dim, self.hidden_dim))
             layers.append(nn.ReLU())
+            if self.dropout > 0.0:
+                layers.append(nn.Dropout(self.dropout))
             in_dim = self.hidden_dim
 
         layers.append(nn.Linear(in_dim, self.output_dim))

--- a/src/models/predictive_model.py
+++ b/src/models/predictive_model.py
@@ -1,6 +1,7 @@
 from typing import Dict, override
 
 import torch
+import torch.nn.functional as F
 
 from src.models.base_model import BaseModel
 from src.models.components.geo_encoders.base_geo_encoder import BaseGeoEncoder
@@ -22,8 +23,9 @@ class PredictiveModel(BaseModel):
         scheduler: torch.optim.lr_scheduler,
         loss_fn: BaseLossFn,
         metrics: MetricsWrapper,
+        normalize_features: bool = True,
     ) -> None:
-        """Implementation of the predictive model with replaceable EO encoder, and prediction head.
+        """Implementation of the predictive model with replaceable GEO encoder, and prediction head.
 
         :param geo_encoder: geo encoder module (replaceable)
         :param prediction_head: prediction head module (replaceable)
@@ -34,6 +36,8 @@ class PredictiveModel(BaseModel):
         :param metrics: metrics to use for model performance evaluation
         :param num_classes: number of target classes
         :param tabular_dim: number of tabular features
+        :param normalize_features: if True, apply L2 normalisation to encoder output before
+            the prediction head (default: True)
         """
 
         super().__init__(trainable_modules, optimizer, scheduler, loss_fn, metrics)
@@ -43,6 +47,8 @@ class PredictiveModel(BaseModel):
 
         # Prediction head
         self.prediction_head = prediction_head
+
+        self.normalize_features = normalize_features
 
     @override
     def setup(self, stage: str) -> None:
@@ -74,6 +80,8 @@ class PredictiveModel(BaseModel):
     @override
     def forward(self, batch: Dict[str, torch.Tensor]) -> torch.Tensor:
         feats = self.geo_encoder(batch)
+        if self.normalize_features:
+            feats = F.normalize(feats, dim=-1)
         return self.prediction_head(feats)
 
     @override

--- a/src/models/predictive_model.py
+++ b/src/models/predictive_model.py
@@ -1,7 +1,6 @@
 from typing import Dict, override
 
 import torch
-import torch.nn.functional as F
 
 from src.models.base_model import BaseModel
 from src.models.components.eo_encoders.base_eo_encoder import BaseEOEncoder
@@ -75,21 +74,22 @@ class PredictiveModel(BaseModel):
     @override
     def forward(self, batch: Dict[str, torch.Tensor]) -> torch.Tensor:
         feats = self.eo_encoder(batch)
-        feats = F.normalize(feats, dim=-1)
         return self.prediction_head(feats)
 
     @override
     def _step(self, batch: Dict[str, torch.Tensor], mode: str = "train") -> torch.Tensor:
-        feats = self.forward(batch)
+        preds = self.forward(batch)
 
         log_kwargs = dict(
-            on_step=False, on_epoch=True, prog_bar=True, sync_dist=True, batch_size=feats.size(0)
+            on_step=False, on_epoch=True, prog_bar=True, sync_dist=True, batch_size=preds.size(0)
         )
-        loss = self.loss_fn(feats, batch.get("target"))
+        loss = self.loss_fn(preds, batch.get("target"))
         self.log(f"{mode}_loss", loss, **log_kwargs)
 
-        metrics = self.metrics(pred=feats, batch=batch, mode=mode)
+        metrics = self.metrics(pred=preds, batch=batch, mode=mode)
         self.log_dict(metrics, **log_kwargs)
+
+        return loss
 
 
 if __name__ == "__main__":

--- a/src/models/predictive_model.py
+++ b/src/models/predictive_model.py
@@ -3,8 +3,8 @@ from typing import Dict, override
 import torch
 
 from src.models.base_model import BaseModel
-from src.models.components.eo_encoders.base_eo_encoder import BaseEOEncoder
-from src.models.components.eo_encoders.multimodal_encoder import MultiModalEncoder
+from src.models.components.geo_encoders.base_geo_encoder import BaseGeoEncoder
+from src.models.components.geo_encoders.multimodal_encoder import MultiModalEncoder
 from src.models.components.loss_fns.base_loss_fn import BaseLossFn
 from src.models.components.metrics.metrics_wrapper import MetricsWrapper
 from src.models.components.pred_heads.linear_pred_head import (
@@ -15,7 +15,7 @@ from src.models.components.pred_heads.linear_pred_head import (
 class PredictiveModel(BaseModel):
     def __init__(
         self,
-        eo_encoder: BaseEOEncoder,
+        geo_encoder: BaseGeoEncoder,
         prediction_head: BasePredictionHead,
         trainable_modules: list[str],
         optimizer: torch.optim.Optimizer,
@@ -25,7 +25,7 @@ class PredictiveModel(BaseModel):
     ) -> None:
         """Implementation of the predictive model with replaceable EO encoder, and prediction head.
 
-        :param eo_encoder: eo encoder module (replaceable)
+        :param geo_encoder: geo encoder module (replaceable)
         :param prediction_head: prediction head module (replaceable)
         :param trainable_modules: list of modules to train (parts/modules or modules, modules)
         :param optimizer: optimizer to use for training
@@ -38,8 +38,8 @@ class PredictiveModel(BaseModel):
 
         super().__init__(trainable_modules, optimizer, scheduler, loss_fn, metrics)
 
-        # EO encoder configuration
-        self.eo_encoder = eo_encoder
+        # Geo encoder configuration
+        self.geo_encoder = geo_encoder
 
         # Prediction head
         self.prediction_head = prediction_head
@@ -58,14 +58,14 @@ class PredictiveModel(BaseModel):
         """Set up encoders and missing adapters/projectors."""
         # TODO: move to multi-modal eo encoder
         if (
-            isinstance(self.eo_encoder, MultiModalEncoder)
-            and self.eo_encoder.use_tabular
-            and not self.eo_encoder._tabular_ready
+            isinstance(self.geo_encoder, MultiModalEncoder)
+            and self.geo_encoder.use_tabular
+            and not self.geo_encoder._tabular_ready
         ):
-            self.eo_encoder.build_tabular_branch(self.tabular_dim)
+            self.geo_encoder.build_tabular_branch(self.tabular_dim)
 
         self.prediction_head.set_dim(
-            input_dim=self.eo_encoder.output_dim, output_dim=self.num_classes
+            input_dim=self.geo_encoder.output_dim, output_dim=self.num_classes
         )
         self.prediction_head.configure_nn()
         if "prediction_head" not in self.trainable_modules:
@@ -73,7 +73,7 @@ class PredictiveModel(BaseModel):
 
     @override
     def forward(self, batch: Dict[str, torch.Tensor]) -> torch.Tensor:
-        feats = self.eo_encoder(batch)
+        feats = self.geo_encoder(batch)
         return self.prediction_head(feats)
 
     @override

--- a/src/models/text_alignment_model.py
+++ b/src/models/text_alignment_model.py
@@ -5,8 +5,8 @@ import torch
 import torch.nn.functional as F
 
 from src.models.base_model import BaseModel
-from src.models.components.eo_encoders.base_eo_encoder import BaseEOEncoder
-from src.models.components.eo_encoders.multimodal_encoder import MultiModalEncoder
+from src.models.components.geo_encoders.base_geo_encoder import BaseGeoEncoder
+from src.models.components.geo_encoders.multimodal_encoder import MultiModalEncoder
 from src.models.components.loss_fns.base_loss_fn import BaseLossFn
 from src.models.components.metrics.contrastive_validation import (
     RetrievalContrastiveValidation,
@@ -23,7 +23,7 @@ from src.models.components.text_encoders.base_text_encoder import (
 class TextAlignmentModel(BaseModel):
     def __init__(
         self,
-        eo_encoder: BaseEOEncoder,
+        geo_encoder: BaseGeoEncoder,
         text_encoder: BaseTextEncoder,
         optimizer: torch.optim.Optimizer,
         scheduler: torch.optim.lr_scheduler,
@@ -35,7 +35,7 @@ class TextAlignmentModel(BaseModel):
     ) -> None:
         """Implementation of contrastive text-eo modality alignment model.
 
-        :param eo_encoder: eo encoder module (replaceable)
+        :param geo_encoder: geo encoder module (replaceable)
         :param text_encoder: text encoder module (replaceable)
         :param optimizer: optimizer to use for training
         :param scheduler: scheduler to use for training
@@ -52,7 +52,7 @@ class TextAlignmentModel(BaseModel):
         self.log_kwargs = dict(on_step=False, on_epoch=True, prog_bar=True, sync_dist=True)
 
         # Encoders configuration
-        self.eo_encoder = eo_encoder
+        self.geo_encoder = geo_encoder
         self.text_encoder = text_encoder
 
         # Prediction head
@@ -76,29 +76,29 @@ class TextAlignmentModel(BaseModel):
         """Set up encoders and missing adapters/projectors."""
         # TODO: move to multi-modal eo encoder
         if (
-            isinstance(self.eo_encoder, MultiModalEncoder)
-            and self.eo_encoder.use_tabular
-            and not self.eo_encoder._tabular_ready
+            isinstance(self.geo_encoder, MultiModalEncoder)
+            and self.geo_encoder.use_tabular
+            and not self.geo_encoder._tabular_ready
         ):
-            self.eo_encoder.build_tabular_branch(self.tabular_dim)
+            self.geo_encoder.build_tabular_branch(self.tabular_dim)
 
         # Extra projector for text encoder if eo and text dim not match
-        if self.eo_encoder.output_dim != self.text_encoder.output_dim:
-            self.text_encoder.add_projector(projected_dim=self.eo_encoder.output_dim)
+        if self.geo_encoder.output_dim != self.text_encoder.output_dim:
+            self.text_encoder.add_projector(projected_dim=self.geo_encoder.output_dim)
             self.trainable_modules.append("text_encoder.extra_projector")
 
         # TODO: if eo==geoclip_img pass on shared mlp
 
         if self.prediction_head is not None:
             self.prediction_head.set_dim(
-                input_dim=self.eo_encoder.output_dim, output_dim=self.num_classes
+                input_dim=self.geo_encoder.output_dim, output_dim=self.num_classes
             )
             self.prediction_head.configure_nn()
 
         # Unify dtypes
-        if self.eo_encoder.dtype != self.text_encoder.dtype:
-            self.eo_encoder = self.eo_encoder.to(self.text_encoder.dtype)
-            print(f"Eo encoder dtype changed to {self.eo_encoder.dtype}")
+        if self.geo_encoder.dtype != self.text_encoder.dtype:
+            self.geo_encoder = self.geo_encoder.to(self.text_encoder.dtype)
+            print(f"Geo encoder dtype changed to {self.geo_encoder.dtype}")
 
     def setup_retrieval_evaluation(self):
         self.concept_configs = self.trainer.datamodule.concept_configs
@@ -125,7 +125,7 @@ class TextAlignmentModel(BaseModel):
         """Model forward logic."""
 
         # Embed modalities
-        eo_feats = self.eo_encoder(batch)
+        eo_feats = self.geo_encoder(batch)
         text_feats = self.text_encoder(batch, mode)
         return eo_feats, text_feats
 

--- a/tests/test_datasets_and_datamodules.py
+++ b/tests/test_datasets_and_datamodules.py
@@ -2,11 +2,12 @@ from src.data.base_dataset import BaseDataset
 from src.data.butterfly_dataset import ButterflyDataset
 from src.data.heat_guatemala_dataset import HeatGuatemalaDataset
 from src.data.satbird_dataset import SatBirdDataset
+from src.data.yield_africa_dataset import YieldAfricaDataset
 
 
 def test_datasets_generic_properties(request, tmp_path, sample_csv):
     """This test checks that all datasets implement the basic properties and methods."""
-    list_datasets = [ButterflyDataset, SatBirdDataset, HeatGuatemalaDataset]
+    list_datasets = [ButterflyDataset, SatBirdDataset, HeatGuatemalaDataset, YieldAfricaDataset]
     use_mock = request.config.getoption("--use-mock")
     if use_mock:
         csv_dir = sample_csv

--- a/tests/test_eo_encoders.py
+++ b/tests/test_eo_encoders.py
@@ -5,17 +5,17 @@ import pandas as pd
 import pytest
 import torch
 
-from src.models.components.eo_encoders.average_encoder import AverageEncoder
-from src.models.components.eo_encoders.base_eo_encoder import BaseEOEncoder
-from src.models.components.eo_encoders.cnn_encoder import CNNEncoder
-from src.models.components.eo_encoders.geoclip import GeoClipCoordinateEncoder
-from src.models.components.eo_encoders.multimodal_encoder import MultiModalEncoder
+from src.models.components.geo_encoders.average_encoder import AverageEncoder
+from src.models.components.geo_encoders.base_geo_encoder import BaseGeoEncoder
+from src.models.components.geo_encoders.cnn_encoder import CNNEncoder
+from src.models.components.geo_encoders.geoclip import GeoClipCoordinateEncoder
+from src.models.components.geo_encoders.multimodal_encoder import MultiModalEncoder
 
 
 # @pytest.mark.slow
-def test_eo_encoder_generic_properties(create_butterfly_dataset):
+def test_geo_encoder_generic_properties(create_butterfly_dataset):
     """This test checks that all EO encoders implement the basic properties and methods."""
-    dict_eo_encoders = {
+    dict_geo_encoders = {
         "geoclip_coords": GeoClipCoordinateEncoder,
         "cnn": CNNEncoder,
         "average": AverageEncoder,
@@ -24,28 +24,28 @@ def test_eo_encoder_generic_properties(create_butterfly_dataset):
     ds, dm = create_butterfly_dataset
     batch = next(iter(dm.train_dataloader()))
 
-    for eo_encoder_name, eo_encoder_class in dict_eo_encoders.items():
-        eo_encoder = eo_encoder_class()
+    for geo_encoder_name, geo_encoder_class in dict_geo_encoders.items():
+        geo_encoder = geo_encoder_class()
 
         assert hasattr(
-            eo_encoder, "eo_encoder"
-        ), f"'eo_encoder' attribute missing in {eo_encoder_class.__name__}."
+            geo_encoder, "geo_encoder"
+        ), f"'geo_encoder' attribute missing in {geo_encoder_class.__name__}."
         assert hasattr(
-            eo_encoder, "output_dim"
-        ), f"'output_dim' attribute missing in {eo_encoder_class.__name__}."
+            geo_encoder, "output_dim"
+        ), f"'output_dim' attribute missing in {geo_encoder_class.__name__}."
         assert hasattr(
-            eo_encoder, "forward"
-        ), f"'forward' method missing in {eo_encoder_class.__name__}."
+            geo_encoder, "forward"
+        ), f"'forward' method missing in {geo_encoder_class.__name__}."
         assert callable(
-            getattr(eo_encoder, "forward")
-        ), f"'forward' is not callable in {eo_encoder_class.__name__}."
+            getattr(geo_encoder, "forward")
+        ), f"'forward' is not callable in {geo_encoder_class.__name__}."
 
-        if eo_encoder_name == "geoclip_coords":
+        if geo_encoder_name == "geoclip_coords":
             # TODO: try more EO encoders when (mock) test data also includes images.
-            feats = eo_encoder.forward(batch)
+            feats = geo_encoder.forward(batch)
             assert isinstance(
                 feats, torch.Tensor
-            ), f"'forward' method of {eo_encoder_class.__name__} does not return a torch.Tensor."
+            ), f"'forward' method of {geo_encoder_class.__name__} does not return a torch.Tensor."
             assert (
                 feats.shape[0] == dm.batch_size_per_device
-            ), f"Output batch size mismatch in {eo_encoder_class.__name__}."
+            ), f"Output batch size mismatch in {geo_encoder_class.__name__}."

--- a/tests/test_geo_encoders.py
+++ b/tests/test_geo_encoders.py
@@ -14,7 +14,7 @@ from src.models.components.geo_encoders.multimodal_encoder import MultiModalEnco
 
 # @pytest.mark.slow
 def test_geo_encoder_generic_properties(create_butterfly_dataset):
-    """This test checks that all EO encoders implement the basic properties and methods."""
+    """This test checks that all GEO encoders implement the basic properties and methods."""
     dict_geo_encoders = {
         "geoclip_coords": GeoClipCoordinateEncoder,
         "cnn": CNNEncoder,
@@ -41,7 +41,7 @@ def test_geo_encoder_generic_properties(create_butterfly_dataset):
         ), f"'forward' is not callable in {geo_encoder_class.__name__}."
 
         if geo_encoder_name == "geoclip_coords":
-            # TODO: try more EO encoders when (mock) test data also includes images.
+            # TODO: try more GEO encoders when (mock) test data also includes images.
             feats = geo_encoder.forward(batch)
             assert isinstance(
                 feats, torch.Tensor

--- a/tests/test_pred_heads.py
+++ b/tests/test_pred_heads.py
@@ -5,7 +5,7 @@ import pandas as pd
 import pytest
 import torch
 
-from src.models.components.eo_encoders.geoclip import GeoClipCoordinateEncoder
+from src.models.components.geo_encoders.geoclip import GeoClipCoordinateEncoder
 from src.models.components.pred_heads.base_pred_head import BasePredictionHead
 from src.models.components.pred_heads.linear_pred_head import LinearPredictionHead
 from src.models.components.pred_heads.mlp_pred_head import MLPPredictionHead

--- a/tests/test_yield_africa.py
+++ b/tests/test_yield_africa.py
@@ -1,0 +1,310 @@
+"""Tests for the yield_africa use case.
+
+The mock CSV mirrors the schema produced by make_model_ready_yield_africa.py:
+  - name_loc, lat, lon
+  - target_yld_ton_ha
+  - feat_* (continuous soil/climate/terrain features + tabular categorical soil texture)
+  - aux_*  (derived classification columns, used for caption generation)
+  - metadata: country, year, location_accuracy
+"""
+
+import hydra
+import pandas as pd
+import pytest
+import torch
+from hydra import compose, initialize
+from hydra.core.global_hydra import GlobalHydra
+
+from src.data.base_datamodule import BaseDataModule
+from src.data.yield_africa_dataset import YieldAfricaDataset
+
+# ---------------------------------------------------------------------------
+# Representative column sets that match the real model_ready_yield-africa.csv
+# ---------------------------------------------------------------------------
+
+MOCK_FEAT_COLS = {
+    # continuous soil features
+    "feat_c_0_20": [1.2, 0.9, 1.5, 1.1, 0.8, 1.4, 1.6, 1.0, 1.3, 1.1],
+    "feat_n_0_20": [0.12, 0.09, 0.15, 0.11, 0.08, 0.14, 0.16, 0.10, 0.13, 0.11],
+    "feat_ph_0_20": [6.1, 5.8, 6.5, 6.0, 5.5, 6.3, 6.8, 5.9, 6.2, 6.4],
+    # continuous climate features
+    "feat_map": [820, 750, 910, 860, 700, 880, 930, 770, 815, 875],
+    "feat_mat": [22.1, 21.5, 23.0, 22.5, 21.0, 22.8, 23.3, 21.9, 22.2, 22.7],
+    # continuous terrain feature
+    "feat_dem": [450, 380, 510, 470, 360, 490, 530, 400, 460, 500],
+    # tabular categorical: soil texture class (real columns, not derived)
+    "feat_tx_0_20_cl": [2, 3, 1, 2, 4, 1, 3, 2, 1, 3],
+    "feat_tx_20_50_cl": [2, 2, 1, 3, 4, 1, 2, 3, 1, 2],
+}
+
+MOCK_AUX_COLS = {
+    # derived classification columns (paired with the continuous feat_* above)
+    "aux_yld_ton_ha_cl": [1, 0, 2, 1, 0, 2, 2, 0, 1, 1],
+    "aux_c_0_20_cl": [1, 0, 2, 1, 0, 2, 2, 0, 1, 1],
+    "aux_ph_0_20_cl": [2, 1, 2, 2, 0, 2, 3, 1, 2, 2],
+    "aux_map_cl": [1, 0, 2, 1, 0, 2, 2, 0, 1, 2],
+}
+
+MOCK_N_ROWS = 10
+MOCK_TABULAR_DIM = len(MOCK_FEAT_COLS)   # 8
+MOCK_N_AUX = len(MOCK_AUX_COLS)          # 4
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def yield_africa_csv(tmp_path) -> str:
+    """Mock CSV with column names matching the real model_ready_yield-africa.csv."""
+    data = {
+        "name_loc": [f"ETH_{i:04d}" for i in range(MOCK_N_ROWS)],
+        "lat": [5.0 + i * 0.5 for i in range(MOCK_N_ROWS)],
+        "lon": [30.0 + i * 0.5 for i in range(MOCK_N_ROWS)],
+        "target_yld_ton_ha": [2.1, 1.8, 3.0, 2.5, 1.2, 2.8, 3.3, 1.9, 2.0, 2.7],
+        "country": ["ETH"] * MOCK_N_ROWS,
+        "year": [2019] * MOCK_N_ROWS,
+        "location_accuracy": [1] * MOCK_N_ROWS,
+    }
+    data.update(MOCK_FEAT_COLS)
+    data.update(MOCK_AUX_COLS)
+
+    mock_dir = tmp_path / "mock"
+    mock_dir.mkdir(parents=True, exist_ok=True)
+    pd.DataFrame(data).to_csv(mock_dir / "model_ready_mock.csv", index=False)
+    return str(tmp_path)
+
+
+@pytest.fixture
+def yield_africa_dataset(yield_africa_csv, tmp_path):
+    """YieldAfricaDataset backed by mock data, features enabled, no aux."""
+    return YieldAfricaDataset(
+        data_dir=yield_africa_csv,
+        cache_dir=str(tmp_path / "cache"),
+        modalities={"coords": {}},
+        use_target_data=True,
+        use_aux_data="none",
+        seed=42,
+        mock=True,
+        use_features=True,
+    )
+
+
+@pytest.fixture
+def yield_africa_dataset_with_aux(yield_africa_csv, tmp_path):
+    """YieldAfricaDataset backed by mock data, features enabled, aux enabled."""
+    return YieldAfricaDataset(
+        data_dir=yield_africa_csv,
+        cache_dir=str(tmp_path / "cache"),
+        modalities={"coords": {}},
+        use_target_data=True,
+        use_aux_data="all",
+        seed=42,
+        mock=True,
+        use_features=True,
+    )
+
+
+@pytest.fixture
+def yield_africa_datamodule(yield_africa_csv, tmp_path):
+    """BaseDataModule wrapping YieldAfricaDataset with a random split."""
+    dataset = YieldAfricaDataset(
+        data_dir=yield_africa_csv,
+        cache_dir=str(tmp_path / "cache"),
+        modalities={"coords": {}},
+        use_target_data=True,
+        use_aux_data="none",
+        seed=42,
+        mock=True,
+        use_features=True,
+    )
+    return BaseDataModule(
+        dataset=dataset,
+        batch_size=4,
+        train_val_test_split=(7, 2, 1),
+        num_workers=0,
+        pin_memory=False,
+        split_mode="random",
+        save_split=False,
+        seed=42,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Dataset tests
+# ---------------------------------------------------------------------------
+
+
+def test_yield_africa_dataset_length(yield_africa_dataset):
+    assert len(yield_africa_dataset) == MOCK_N_ROWS
+
+
+def test_yield_africa_dataset_sample_keys(yield_africa_dataset):
+    sample = yield_africa_dataset[0]
+    assert "eo" in sample
+    assert "coords" in sample["eo"]
+    assert "tabular" in sample["eo"]
+    assert "target" in sample
+
+
+def test_yield_africa_dataset_sample_shapes(yield_africa_dataset):
+    sample = yield_africa_dataset[0]
+    assert sample["eo"]["coords"].shape == (2,)
+    assert sample["eo"]["tabular"].shape == (MOCK_TABULAR_DIM,)
+    assert sample["target"].shape == (1,)
+
+
+def test_yield_africa_dataset_sample_dtypes(yield_africa_dataset):
+    sample = yield_africa_dataset[0]
+    assert sample["eo"]["coords"].dtype == torch.float32
+    assert sample["eo"]["tabular"].dtype == torch.float32
+    assert sample["target"].dtype == torch.float32
+
+
+def test_yield_africa_dataset_target_name(yield_africa_dataset):
+    assert yield_africa_dataset.target_names == ["target_yld_ton_ha"]
+
+
+def test_yield_africa_dataset_attributes(yield_africa_dataset):
+    assert yield_africa_dataset.num_classes == 1
+    assert yield_africa_dataset.tabular_dim == MOCK_TABULAR_DIM
+    assert set(yield_africa_dataset.feat_names) == set(MOCK_FEAT_COLS.keys())
+
+
+def test_yield_africa_dataset_feat_prefix(yield_africa_dataset):
+    """All tabular features must carry the feat_ prefix."""
+    for name in yield_africa_dataset.feat_names:
+        assert name.startswith("feat_"), f"Unexpected feature name: {name}"
+
+
+def test_yield_africa_dataset_coords_values(yield_africa_dataset):
+    """Coordinates returned must match the CSV values."""
+    sample = yield_africa_dataset[0]
+    coords = sample["eo"]["coords"]
+    assert coords[0].item() == pytest.approx(5.0)   # lat of row 0
+    assert coords[1].item() == pytest.approx(30.0)  # lon of row 0
+
+
+def test_yield_africa_dataset_target_values(yield_africa_dataset):
+    """Target values returned must match the CSV values."""
+    expected = [2.1, 1.8, 3.0, 2.5, 1.2, 2.8, 3.3, 1.9, 2.0, 2.7]
+    for idx, exp in enumerate(expected):
+        sample = yield_africa_dataset[idx]
+        assert sample["target"][0].item() == pytest.approx(exp, rel=1e-5)
+
+
+def test_yield_africa_dataset_no_features(yield_africa_csv, tmp_path):
+    """With use_features=False, tabular is absent and tabular_dim is None."""
+    ds = YieldAfricaDataset(
+        data_dir=yield_africa_csv,
+        cache_dir=str(tmp_path / "cache"),
+        modalities={"coords": {}},
+        use_target_data=True,
+        use_aux_data="none",
+        seed=0,
+        mock=True,
+        use_features=False,
+    )
+    sample = ds[0]
+    assert "tabular" not in sample["eo"]
+    assert ds.tabular_dim is None
+
+
+def test_yield_africa_dataset_aux_keys(yield_africa_dataset_with_aux):
+    """When aux is enabled, sample must contain an 'aux' dict."""
+    sample = yield_africa_dataset_with_aux[0]
+    assert "aux" in sample
+    assert "aux" in sample["aux"]
+
+
+def test_yield_africa_dataset_aux_columns(yield_africa_dataset_with_aux):
+    """Aux columns picked up must match the aux_* columns in the mock CSV."""
+    resolved_aux = yield_africa_dataset_with_aux.use_aux_data["aux"]
+    assert set(resolved_aux) == set(MOCK_AUX_COLS.keys())
+
+
+def test_yield_africa_dataset_aux_shape(yield_africa_dataset_with_aux):
+    """Aux tensor shape must equal the number of aux_* columns."""
+    sample = yield_africa_dataset_with_aux[0]
+    assert sample["aux"]["aux"].shape == (MOCK_N_AUX,)
+
+
+# ---------------------------------------------------------------------------
+# Datamodule tests
+# ---------------------------------------------------------------------------
+
+
+def test_yield_africa_datamodule_split_sizes(yield_africa_datamodule):
+    dm = yield_africa_datamodule
+    assert len(dm.data_train) == 7
+    assert len(dm.data_val) == 2
+    assert len(dm.data_test) == 1
+
+
+def test_yield_africa_datamodule_train_loader(yield_africa_datamodule):
+    dm = yield_africa_datamodule
+    dm.setup()
+    batch = next(iter(dm.train_dataloader()))
+    assert "eo" in batch
+    assert "coords" in batch["eo"]
+    assert "tabular" in batch["eo"]
+    assert batch["eo"]["coords"].shape == (4, 2)
+    assert batch["eo"]["tabular"].shape == (4, MOCK_TABULAR_DIM)
+    assert batch["target"].shape == (4, 1)
+
+
+def test_yield_africa_datamodule_split_deterministic(yield_africa_csv, tmp_path):
+    def make_dm():
+        dataset = YieldAfricaDataset(
+            data_dir=yield_africa_csv,
+            cache_dir=str(tmp_path / "cache"),
+            modalities={"coords": {}},
+            use_target_data=True,
+            use_aux_data="none",
+            seed=42,
+            mock=True,
+        )
+        return BaseDataModule(
+            dataset=dataset,
+            batch_size=4,
+            train_val_test_split=(7, 2, 1),
+            num_workers=0,
+            split_mode="random",
+            save_split=False,
+            seed=42,
+        )
+
+    dm1, dm2 = make_dm(), make_dm()
+    assert dm1.data_train.indices == dm2.data_train.indices
+    assert dm1.data_val.indices == dm2.data_val.indices
+
+
+# ---------------------------------------------------------------------------
+# Config tests
+# ---------------------------------------------------------------------------
+
+
+def test_yield_africa_config_loads():
+    GlobalHydra.instance().clear()
+    with initialize(version_base="1.3", config_path="../configs"):
+        cfg = compose(
+            config_name="train.yaml",
+            overrides=["experiment=yield_africa_tabular_reg", "hydra.job.chdir=false"],
+        )
+    assert cfg.data._target_ == "src.data.base_datamodule.BaseDataModule"
+    assert cfg.data.dataset._target_ == "src.data.yield_africa_dataset.YieldAfricaDataset"
+    assert cfg.model._target_ == "src.models.predictive_model.PredictiveModel"
+    GlobalHydra.instance().clear()
+
+
+def test_yield_africa_model_instantiates():
+    GlobalHydra.instance().clear()
+    with initialize(version_base="1.3", config_path="../configs"):
+        cfg = compose(
+            config_name="train.yaml",
+            overrides=["experiment=yield_africa_tabular_reg", "hydra.job.chdir=false"],
+        )
+    model = hydra.utils.instantiate(cfg.model)
+    assert model is not None
+    GlobalHydra.instance().clear()

--- a/tests/test_yield_africa.py
+++ b/tests/test_yield_africa.py
@@ -46,7 +46,11 @@ MOCK_AUX_COLS = {
 }
 
 MOCK_N_ROWS = 10
-MOCK_TABULAR_DIM = len(MOCK_FEAT_COLS)   # 8
+# feat_year (1) + feat_country_{code} (8) are injected by YieldAfricaDataset
+# when country and year columns are present, so the effective tabular dim grows.
+from src.data.yield_africa_dataset import _ALL_COUNTRIES
+MOCK_INJECTED_FEAT_NAMES = {"feat_year"} | {f"feat_country_{c}" for c in _ALL_COUNTRIES}
+MOCK_TABULAR_DIM = len(MOCK_FEAT_COLS) + len(MOCK_INJECTED_FEAT_NAMES)  # 8 + 9 = 17
 MOCK_N_AUX = len(MOCK_AUX_COLS)          # 4
 
 
@@ -169,7 +173,8 @@ def test_yield_africa_dataset_target_name(yield_africa_dataset):
 def test_yield_africa_dataset_attributes(yield_africa_dataset):
     assert yield_africa_dataset.num_classes == 1
     assert yield_africa_dataset.tabular_dim == MOCK_TABULAR_DIM
-    assert set(yield_africa_dataset.feat_names) == set(MOCK_FEAT_COLS.keys())
+    expected_feat_names = set(MOCK_FEAT_COLS.keys()) | MOCK_INJECTED_FEAT_NAMES
+    assert set(yield_africa_dataset.feat_names) == expected_feat_names
 
 
 def test_yield_africa_dataset_feat_prefix(yield_africa_dataset):


### PR DESCRIPTION
This Pull Request introduces the necessary data structures, configurations, and model components to support crop yield regression for East and Southern Africa.

Changes:
 - Added YieldAfricaDataset in src/data/yield_africa_dataset.py, which supports filtering by country and year, and handles both coordinate and tabular features (soil, climate, etc.).
 - Added make_model_ready_yield_africa.py script to transform raw Excel use case data into a model-ready CSV format.

Model Enhancements:
 - Refactored PredictiveModel to correctly return the loss in _step and renamed internal variables for clarity (e.g., feats to preds when referring to model output).
 - Removed hardcoded F.normalize from the forward pass of PredictiveModel to allow for more flexible encoder/head combinations.
 - Added HuberLoss as a new loss function component.

Configurations:
 - Added Hydra configurations for the Africa yield dataset, regression metrics, and experiment setup (yield_africa_tabular_reg.yaml).