### PR TITLE
Feature/spatial splits

### DIFF
--- a/configs/data/yield_africa_spatial.yaml
+++ b/configs/data/yield_africa_spatial.yaml
@@ -1,0 +1,33 @@
+_target_: src.data.base_datamodule.BaseDataModule
+
+dataset:
+  _target_: src.data.yield_africa_dataset.YieldAfricaDataset
+  data_dir: ${paths.data_dir}
+  modalities:
+    coords: {}
+  use_target_data: true
+  use_features: true
+  use_aux_data: none
+  seed: ${seed}
+  cache_dir: ${paths.cache_dir}
+  # Include all countries and years so the split file determines the partition.
+  countries: ["BF", "BUR", "ETH", "KEN", "MAL", "RWA", "TAN", "ZAM"]
+  years: [2014, 2016, 2017, 2018, 2019, 2020, 2021, 2023, 2024]
+  exclude_countries: null
+  exclude_years: null
+
+batch_size: 64
+num_workers: 0
+pin_memory: false
+
+# Spatial-cluster split loaded from a pre-generated file.
+# Generate split files first (produces 10 km, 25 km, and 50 km variants):
+#   python src/data_preprocessing/yield_africa_spatial_splits.py --data_dir <data_dir>
+#
+# Override saved_split_file_name at the command line to change the cluster distance:
+#   python src/train.py experiment=yield_africa_tabular_spatial \
+#     data.saved_split_file_name=split_spatial_10km.pth
+split_mode: "from_file"
+saved_split_file_name: "split_spatial_25km.pth"
+save_split: false
+seed: ${seed}

--- a/configs/data/yield_africa_tessera_loco.yaml
+++ b/configs/data/yield_africa_tessera_loco.yaml
@@ -1,0 +1,39 @@
+_target_: src.data.base_datamodule.BaseDataModule
+
+dataset:
+  _target_: src.data.yield_africa_dataset.YieldAfricaDataset
+  data_dir: ${paths.data_dir}
+  modalities:
+    tessera:
+      # size must match the tile_size used when running the preprocessing script.
+      # Default: 9 pixels (set by yield_africa_tessera_preprocess.py --tile_size).
+      size: 9
+      format: npy
+      # year is intentionally omitted: yield_africa fetches per-record year tiles
+      # via the preprocessing script rather than a single bulk-year download.
+  use_target_data: true
+  use_features: true
+  use_aux_data: none
+  seed: ${seed}
+  cache_dir: ${paths.cache_dir}
+  # Include all countries and years so the split file determines the partition.
+  countries: ["BF", "BUR", "ETH", "KEN", "MAL", "RWA", "TAN", "ZAM"]
+  years: [2014, 2016, 2017, 2018, 2019, 2020, 2021, 2023, 2024]
+  exclude_countries: null
+  exclude_years: null
+
+batch_size: 64
+num_workers: 0
+pin_memory: false
+
+# Leave-one-country-out split loaded from a pre-generated file.
+# Generate split files first:
+#   python src/data_preprocessing/yield_africa_loco_splits.py --data_dir <data_dir>
+#
+# Override saved_split_file_name at the command line to change the held-out country:
+#   python src/train.py experiment=yield_africa_tessera_fusion_loco \
+#     data.saved_split_file_name=split_loco_RWA.pth
+split_mode: "from_file"
+saved_split_file_name: "split_loco_KEN.pth"
+save_split: false
+seed: ${seed}

--- a/configs/data/yield_africa_tessera_spatial.yaml
+++ b/configs/data/yield_africa_tessera_spatial.yaml
@@ -1,0 +1,39 @@
+_target_: src.data.base_datamodule.BaseDataModule
+
+dataset:
+  _target_: src.data.yield_africa_dataset.YieldAfricaDataset
+  data_dir: ${paths.data_dir}
+  modalities:
+    tessera:
+      # size must match the tile_size used when running the preprocessing script.
+      # Default: 9 pixels (set by yield_africa_tessera_preprocess.py --tile_size).
+      size: 9
+      format: npy
+      # year is intentionally omitted: yield_africa fetches per-record year tiles
+      # via the preprocessing script rather than a single bulk-year download.
+  use_target_data: true
+  use_features: true
+  use_aux_data: none
+  seed: ${seed}
+  cache_dir: ${paths.cache_dir}
+  # Include all countries and years so the split file determines the partition.
+  countries: ["BF", "BUR", "ETH", "KEN", "MAL", "RWA", "TAN", "ZAM"]
+  years: [2014, 2016, 2017, 2018, 2019, 2020, 2021, 2023, 2024]
+  exclude_countries: null
+  exclude_years: null
+
+batch_size: 64
+num_workers: 0
+pin_memory: false
+
+# Spatial-cluster split loaded from a pre-generated file.
+# Generate split files first (produces 10 km, 25 km, and 50 km variants):
+#   python src/data_preprocessing/yield_africa_spatial_splits.py --data_dir <data_dir>
+#
+# Override saved_split_file_name at the command line to change the cluster distance:
+#   python src/train.py experiment=yield_africa_tessera_fusion_spatial \
+#     data.saved_split_file_name=split_spatial_10km.pth
+split_mode: "from_file"
+saved_split_file_name: "split_spatial_25km.pth"
+save_split: false
+seed: ${seed}

--- a/configs/experiment/yield_africa_fusion_loco.yaml
+++ b/configs/experiment/yield_africa_fusion_loco.yaml
@@ -1,0 +1,33 @@
+# @package _global_
+# configs/experiment/yield_africa_fusion_loco.yaml
+# GeoClip + tabular fusion model evaluated with leave-one-country-out split.
+# Default held-out country: KEN (largest, most representative test set).
+#
+# Generate split files first:
+#   python src/data_preprocessing/yield_africa_loco_splits.py --data_dir <data_dir>
+#
+# To evaluate on a different held-out country:
+#   python src/train.py experiment=yield_africa_fusion_loco \
+#     data.saved_split_file_name=split_loco_RWA.pth
+
+defaults:
+  - override /model: yield_fusion_reg
+  - override /data: yield_africa_loco
+  - override /metrics: yield_africa_regression
+
+tags: ["yield_africa", "fusion", "regression", "loco"]
+seed: 12345
+
+trainer:
+  min_epochs: 1
+  max_epochs: 150
+
+data:
+  batch_size: 64
+
+logger:
+  wandb:
+    tags: ${tags}
+    group: "yield_africa"
+  aim:
+    experiment: "yield_africa"

--- a/configs/experiment/yield_africa_fusion_spatial.yaml
+++ b/configs/experiment/yield_africa_fusion_spatial.yaml
@@ -1,0 +1,33 @@
+# @package _global_
+# configs/experiment/yield_africa_fusion_spatial.yaml
+# GeoClip + tabular fusion model evaluated with a spatial-cluster split.
+# Default cluster distance: 25 km (split_spatial_25km.pth).
+#
+# Generate split files first:
+#   python src/data_preprocessing/yield_africa_spatial_splits.py --data_dir <data_dir>
+#
+# To evaluate at a different cluster distance:
+#   python src/train.py experiment=yield_africa_fusion_spatial \
+#     data.saved_split_file_name=split_spatial_10km.pth
+
+defaults:
+  - override /model: yield_fusion_reg
+  - override /data: yield_africa_spatial
+  - override /metrics: yield_africa_regression
+
+tags: ["yield_africa", "fusion", "regression", "spatial"]
+seed: 12345
+
+trainer:
+  min_epochs: 1
+  max_epochs: 150
+
+data:
+  batch_size: 64
+
+logger:
+  wandb:
+    tags: ${tags}
+    group: "yield_africa"
+  aim:
+    experiment: "yield_africa"

--- a/configs/experiment/yield_africa_tabular_spatial.yaml
+++ b/configs/experiment/yield_africa_tabular_spatial.yaml
@@ -1,0 +1,33 @@
+# @package _global_
+# configs/experiment/yield_africa_tabular_spatial.yaml
+# Tabular-only model evaluated with a spatial-cluster split.
+# Default cluster distance: 25 km (split_spatial_25km.pth).
+#
+# Generate split files first:
+#   python src/data_preprocessing/yield_africa_spatial_splits.py --data_dir <data_dir>
+#
+# To evaluate at a different cluster distance:
+#   python src/train.py experiment=yield_africa_tabular_spatial \
+#     data.saved_split_file_name=split_spatial_10km.pth
+
+defaults:
+  - override /model: yield_tabular_reg
+  - override /data: yield_africa_spatial
+  - override /metrics: yield_africa_regression
+
+tags: ["yield_africa", "tabular_only", "regression", "spatial"]
+seed: 12345
+
+trainer:
+  min_epochs: 1
+  max_epochs: 150
+
+data:
+  batch_size: 64
+
+logger:
+  wandb:
+    tags: ${tags}
+    group: "yield_africa"
+  aim:
+    experiment: "yield_africa"

--- a/configs/experiment/yield_africa_tessera_fusion_loco.yaml
+++ b/configs/experiment/yield_africa_tessera_fusion_loco.yaml
@@ -1,0 +1,38 @@
+# @package _global_
+# configs/experiment/yield_africa_tessera_fusion_loco.yaml
+# TESSERA + tabular fusion model evaluated with leave-one-country-out split.
+# Default held-out country: KEN (largest, most representative test set).
+#
+# Requires:
+#   1. TESSERA tiles pre-fetched:
+#        python src/data_preprocessing/yield_africa_tessera_preprocess.py --data_dir <data_dir>
+#   2. LOCO split files pre-generated:
+#        python src/data_preprocessing/yield_africa_loco_splits.py --data_dir <data_dir>
+#
+# To evaluate on a different held-out country:
+#   python src/train.py experiment=yield_africa_tessera_fusion_loco \
+#     data.saved_split_file_name=split_loco_RWA.pth
+
+defaults:
+  - override /model: yield_tessera_fusion_reg
+  - override /data: yield_africa_tessera_loco
+  - override /metrics: yield_africa_regression
+
+tags: ["yield_africa", "tessera_fusion", "regression", "loco"]
+seed: 12345
+
+trainer:
+  min_epochs: 1
+  max_epochs: 150
+
+data:
+  batch_size: 64
+  dataset:
+    use_features: true
+
+logger:
+  wandb:
+    tags: ${tags}
+    group: "yield_africa"
+  aim:
+    experiment: "yield_africa"

--- a/configs/experiment/yield_africa_tessera_fusion_spatial.yaml
+++ b/configs/experiment/yield_africa_tessera_fusion_spatial.yaml
@@ -1,0 +1,38 @@
+# @package _global_
+# configs/experiment/yield_africa_tessera_fusion_spatial.yaml
+# TESSERA + tabular fusion model evaluated with a spatial-cluster split.
+# Default cluster distance: 25 km (split_spatial_25km.pth).
+#
+# Requires:
+#   1. TESSERA tiles pre-fetched:
+#        python src/data_preprocessing/yield_africa_tessera_preprocess.py --data_dir <data_dir>
+#   2. Spatial split files pre-generated:
+#        python src/data_preprocessing/yield_africa_spatial_splits.py --data_dir <data_dir>
+#
+# To evaluate at a different cluster distance:
+#   python src/train.py experiment=yield_africa_tessera_fusion_spatial \
+#     data.saved_split_file_name=split_spatial_10km.pth
+
+defaults:
+  - override /model: yield_tessera_fusion_reg
+  - override /data: yield_africa_tessera_spatial
+  - override /metrics: yield_africa_regression
+
+tags: ["yield_africa", "tessera_fusion", "regression", "spatial"]
+seed: 12345
+
+trainer:
+  min_epochs: 1
+  max_epochs: 150
+
+data:
+  batch_size: 64
+  dataset:
+    use_features: true
+
+logger:
+  wandb:
+    tags: ${tags}
+    group: "yield_africa"
+  aim:
+    experiment: "yield_africa"

--- a/configs/metrics/yield_africa_regression.yaml
+++ b/configs/metrics/yield_africa_regression.yaml
@@ -1,7 +1,8 @@
 _target_: src.models.components.metrics.metrics_wrapper.MetricsWrapper
 
 metrics:
-  - _target_: src.models.components.loss_fns.mse_loss.MSELoss
+  - _target_: src.models.components.loss_fns.huber_loss.HuberLoss
   - _target_: src.models.components.loss_fns.rmse_loss.RMSELoss
   - _target_: src.models.components.loss_fns.mae_loss.MAELoss
+  - _target_: src.models.components.loss_fns.rrmse_loss.RRMSELoss
   - _target_: src.models.components.metrics.r2.RSquared

--- a/src/data/base_datamodule.py
+++ b/src/data/base_datamodule.py
@@ -1,12 +1,12 @@
 import copy
 import os
+import time
 from functools import partial
 from typing import Any, Dict, List, Tuple
 
 import numpy as np
 import pandas as pd
 import torch
-from geopy.distance import distance as geodist  # avoid naming confusion
 from lightning import LightningDataModule
 from sklearn.cluster import DBSCAN
 from sklearn.model_selection import GroupShuffleSplit
@@ -121,20 +121,27 @@ class BaseDataModule(LightningDataModule):
                 }
 
         elif self.hparams.split_mode == "spatial_clusters":
-            print("Splitting dataset using spatial clusters. This can take a while...")
-            coords = np.array([self.dataset.df.lat, self.dataset.df.lon]).T
-            if len(coords) > 2000:
-                print(
-                    "Warning: DBSCAN clustering on more than 2000 samples may be slow. Maybe set n_jobs in DBScan?"
-                )
-            # 4000 m distance between points. Use geodist to calculate true distance.
             min_dist = self.hparams.spatial_split_distance_m
+            coords = np.array([self.dataset.df.lat, self.dataset.df.lon]).T
+            n = len(coords)
+            print(
+                f"Splitting {n} samples into spatial clusters "
+                f"(eps={min_dist / 1000:.1f} km, haversine, n_jobs=-1)..."
+            )
+            # Convert (lat, lon) degrees to radians for sklearn's haversine metric.
+            # haversine returns arc length on the unit sphere, so eps must be in radians.
+            _EARTH_RADIUS_M = 6_371_000
+            coords_rad = np.radians(coords)
+            eps_rad = min_dist / _EARTH_RADIUS_M
+            t0 = time.time()
             clustering = DBSCAN(
-                eps=min_dist,
-                metric=lambda u, v: geodist(u, v).meters,
+                eps=eps_rad,
+                metric="haversine",
+                algorithm="ball_tree",
                 min_samples=2,
-            ).fit(coords)
-            print("Clustering done. Creating splits and saving.")
+                n_jobs=-1,
+            ).fit(coords_rad)
+            print(f"DBSCAN done in {time.time() - t0:.1f}s. Creating splits...")
             # Non-clustered points are labeled -1. Change to new cluster label.
             clusters = copy.deepcopy(clustering.labels_)
             new_cl = np.max(clusters) + 1

--- a/src/data/yield_africa_dataset.py
+++ b/src/data/yield_africa_dataset.py
@@ -12,6 +12,7 @@ import logging
 import os
 from typing import Any, Dict, List, override
 
+import numpy as np
 import pandas as pd
 import torch
 
@@ -26,6 +27,16 @@ log = logging.getLogger(__name__)
 # Used to produce a consistent one-hot encoding regardless of which
 # countries are present after filtering.
 _ALL_COUNTRIES = ["BF", "BUR", "ETH", "KEN", "MAL", "RWA", "TAN", "ZAM"]
+
+# Study-area bounds used to normalise coordinates before computing Fourier
+# harmonics.  Normalising to the actual data extent (rather than ±90°/±180°)
+# makes the harmonics maximally discriminative within the dataset.
+#   Latitude  : 30°S – 15°N  → centre −7.5°, half-range 22.5°
+#   Longitude : 10°E – 45°E  → centre  27.5°, half-range 17.5°
+_LAT_CENTER = -7.5
+_LAT_HALF_RANGE = 22.5
+_LON_CENTER = 27.5
+_LON_HALF_RANGE = 17.5
 
 
 class YieldAfricaDataset(BaseDataset):
@@ -45,11 +56,20 @@ class YieldAfricaDataset(BaseDataset):
     the model-ready CSV and are picked up via the `feat_` column prefix.
     They do NOT need to be listed in `modalities`.
 
-    In addition to the CSV feat_* columns, `year` and one-hot `country`
-    encodings are injected as `feat_year` and `feat_country_{CODE}` so that
-    the model can condition on inter-annual and cross-country variation.
-    The one-hot set always covers `_ALL_COUNTRIES` (8 countries) so that
-    `tabular_dim` is stable regardless of the country filter applied.
+    In addition to the CSV feat_* columns, the following features are injected:
+      - ``feat_year``            : normalised year (zero-mean, unit-std)
+      - ``feat_country_{CODE}``  : one-hot country encoding (always 8 columns,
+                                   stable across country filters)
+      - ``feat_lat_sin1/cos1``   : fundamental latitude harmonic, normalised to
+                                   the study-area extent (30°S–15°N)
+      - ``feat_lat_sin2/cos2``   : second latitude harmonic (captures bimodal vs.
+                                   unimodal rainfall boundary near the equator)
+      - ``feat_lon_sin1/cos1``   : fundamental longitude harmonic, normalised to
+                                   the study-area extent (10°E–45°E)
+
+    The Fourier harmonics encode the ITCZ-driven latitudinal climate gradient at
+    interpretable frequencies, complementing GeoCLIP's photo-derived coordinate
+    embedding and enabling richer text captions for the explainability component.
     """
 
     def __init__(
@@ -93,6 +113,28 @@ class YieldAfricaDataset(BaseDataset):
             }
             for code in _ALL_COUNTRIES:
                 new_cols[f"feat_country_{code}"] = (self.df["country"] == code).astype(float)
+
+            # Fourier harmonics of coordinates, normalised to the study-area extent.
+            #
+            # Africa's agricultural patterns follow the ITCZ-driven latitudinal climate
+            # gradient: rainfall regime (uni- vs. bimodal), growing-season length, and
+            # temperature vary sinusoidally with latitude.  Explicit harmonics give the
+            # model these signals directly and at interpretable frequencies, complementing
+            # GeoCLIP's learned (but photo-derived) coordinate embedding.
+            #
+            # lat_norm / lon_norm ∈ [-1, 1] within the study area; π * norm ∈ [-π, π].
+            # Two harmonics for latitude (captures both the broad N-S gradient and the
+            # equatorial-bimodal / southern-unimodal boundary); one for longitude
+            # (east-west Indian Ocean moisture gradient).
+            lat_norm = (self.df["lat"].astype(float) - _LAT_CENTER) / _LAT_HALF_RANGE
+            lon_norm = (self.df["lon"].astype(float) - _LON_CENTER) / _LON_HALF_RANGE
+            new_cols["feat_lat_sin1"] = np.sin(np.pi * lat_norm)
+            new_cols["feat_lat_cos1"] = np.cos(np.pi * lat_norm)
+            new_cols["feat_lat_sin2"] = np.sin(2.0 * np.pi * lat_norm)
+            new_cols["feat_lat_cos2"] = np.cos(2.0 * np.pi * lat_norm)
+            new_cols["feat_lon_sin1"] = np.sin(np.pi * lon_norm)
+            new_cols["feat_lon_cos1"] = np.cos(np.pi * lon_norm)
+
             self.df = pd.concat([self.df, pd.DataFrame(new_cols, index=self.df.index)], axis=1)
 
         # Apply country/year filters to self.df and rebuild records.

--- a/src/data_preprocessing/yield_africa_spatial_splits.py
+++ b/src/data_preprocessing/yield_africa_spatial_splits.py
@@ -1,0 +1,326 @@
+"""Generate spatial-cluster split files for the yield_africa dataset.
+
+Location: src/data_preprocessing/yield_africa_spatial_splits.py
+
+Uses DBSCAN with a haversine distance metric to group nearby field locations
+into clusters, then assigns whole clusters to train/val/test so that no
+geographically close points straddle a split boundary.
+
+One `.pth` file is written per distance threshold to
+`{data_dir}/yield_africa/splits/split_spatial_{distance_km}km.pth`.
+
+Split layout
+------------
+- train : ~70 % of records (cluster-aligned)
+- val   : ~15 % of records (cluster-aligned)
+- test  : ~15 % of records (cluster-aligned)
+
+Proportions are approximate because whole clusters are kept intact.
+
+The files are consumed by BaseDataModule when `split_mode: from_file` and
+`saved_split_file_name: split_spatial_{distance_km}km.pth`.
+
+Usage
+-----
+    # Generate the default set of splits (10 km, 25 km, 50 km)
+    python src/data_preprocessing/yield_africa_spatial_splits.py --data_dir data/
+
+    # Generate a single split at a specific distance
+    python src/data_preprocessing/yield_africa_spatial_splits.py --data_dir data/ --distance_km 25
+
+    # Generate multiple distances in one run
+    python src/data_preprocessing/yield_africa_spatial_splits.py --data_dir data/ --distance_km 10 25 50
+
+Notes
+-----
+- DBSCAN uses sklearn's built-in haversine metric with a BallTree spatial index
+  and n_jobs=-1, which is significantly faster than a Python geodesic lambda.
+  Haversine vs. true geodesic error is < 0.1% at distances up to ~100 km.
+- `min_samples=2` means a pair of fields within `distance_km` of each other
+  forms a cluster; isolated fields each become their own singleton cluster.
+- All clusters are kept intact across the split boundary, so the test set
+  contains no locations geographically close to any training location.
+"""
+
+import argparse
+import copy
+import logging
+import time
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+import torch
+from sklearn.cluster import DBSCAN
+
+log = logging.getLogger(__name__)
+
+DATASET_NAME = "yield_africa"
+MODEL_READY_CSV = f"model_ready_{DATASET_NAME}.csv"
+
+# Default distances to generate when no --distance_km is supplied.
+DEFAULT_DISTANCES_KM = [10, 25, 50]
+
+# Split proportions (must sum to 1.0).
+TRAIN_FRAC = 0.70
+VAL_FRAC = 0.15
+TEST_FRAC = 0.15
+
+# Fixed random seed for GroupShuffleSplit.
+SEED = 12345
+
+
+def make_spatial_split(
+    df: pd.DataFrame,
+    distance_m: int,
+    train_val_test_split: tuple[float, float, float] = (TRAIN_FRAC, VAL_FRAC, TEST_FRAC),
+    seed: int = SEED,
+) -> dict:
+    """Return a split-indices dict using DBSCAN spatial clustering.
+
+    :param df: full model-ready dataframe (must contain 'lat', 'lon', 'name_loc')
+    :param distance_m: DBSCAN eps in metres — pairs of fields closer than this
+        value are assigned to the same cluster
+    :param train_val_test_split: (train, val, test) proportions, must sum to 1.0
+    :param seed: random seed for GroupShuffleSplit
+    :return: dict with 'train_indices', 'val_indices', 'test_indices' as
+        pd.Series of name_loc strings, plus 'clusters' as a numpy array of
+        cluster labels (same length as df)
+    """
+    # Deduplicate to unique (lat, lon) locations before clustering.
+    # yield_africa has ~9 rows per location (one per year); running DBSCAN on all
+    # rows produces giant clusters whose row counts are unequal, causing
+    # GroupShuffleSplit (which splits by cluster count) to produce badly skewed
+    # train/val/test proportions.  Clustering unique locations and propagating
+    # the split back to all rows fixes this.
+    unique_locs = df.drop_duplicates(subset=["lat", "lon"]).reset_index(drop=True)
+    n_unique = len(unique_locs)
+    n_total = len(df)
+    if n_unique < n_total:
+        print(
+            f"  Deduplicating: {n_unique} unique locations from {n_total} rows "
+            f"(~{n_total / n_unique:.1f} rows/location)."
+        )
+
+    # Convert (lat, lon) degrees to radians for sklearn's haversine metric.
+    # haversine returns arc length on the unit sphere, so eps must be in radians.
+    # Error vs. true geodesic is < 0.1% at distances up to ~100 km.
+    _EARTH_RADIUS_M = 6_371_000
+    coords_rad = np.radians(np.array([unique_locs["lat"].values, unique_locs["lon"].values]).T)
+    eps_rad = distance_m / _EARTH_RADIUS_M
+
+    print(
+        f"  Running DBSCAN (eps={distance_m / 1000:.1f} km, haversine, "
+        f"n={n_unique} locations, n_jobs=-1)..."
+    )
+    t0 = time.time()
+    clustering = DBSCAN(
+        eps=eps_rad,
+        metric="haversine",
+        algorithm="ball_tree",
+        min_samples=2,
+        n_jobs=-1,
+    ).fit(coords_rad)
+    print(f"  DBSCAN done in {time.time() - t0:.1f}s.")
+
+    # Noise points (label -1) each become their own unique cluster so that
+    # GroupShuffleSplit can assign them individually to a split partition.
+    clusters = copy.deepcopy(clustering.labels_)
+    next_label = int(np.max(clusters)) + 1
+    for i, label in enumerate(clusters):
+        if label == -1:
+            clusters[i] = next_label
+            next_label += 1
+
+    n_clusters = len(np.unique(clusters))
+    n_noise = int(np.sum(clustering.labels_ == -1))
+    print(f"  Clustering done: {n_clusters} location clusters ({n_noise} singleton noise points).")
+
+    train_prop, val_prop, test_prop = train_val_test_split
+
+    # Greedy size-aware cluster assignment.
+    #
+    # GroupShuffleSplit splits by cluster *count*, not by sample count.  When the
+    # cluster size distribution is heavily skewed (a few mega-clusters + many
+    # tiny 2-location clusters), this produces badly imbalanced splits.
+    #
+    # Instead: shuffle clusters for randomness, sort by size descending, then
+    # assign each cluster to whichever split is furthest below its sample-count
+    # target.  Each cluster goes to exactly one split, so there is no overlap.
+    rng = np.random.default_rng(seed)
+    unique_clusters, cluster_sizes = np.unique(clusters, return_counts=True)
+
+    # Shuffle first so ties are broken randomly, then sort by descending size.
+    shuffle_order = rng.permutation(len(unique_clusters))
+    unique_clusters = unique_clusters[shuffle_order]
+    cluster_sizes = cluster_sizes[shuffle_order]
+    size_order = np.argsort(-cluster_sizes)
+    unique_clusters = unique_clusters[size_order]
+    cluster_sizes = cluster_sizes[size_order]
+
+    target_train = n_unique * train_prop
+    target_val = n_unique * val_prop
+    target_test = n_unique * test_prop
+    train_clusters, val_clusters, test_clusters = [], [], []
+    count_train, count_val, count_test = 0, 0, 0
+
+    for cluster_id, size in zip(unique_clusters, cluster_sizes):
+        deficit_train = target_train - count_train
+        deficit_val = target_val - count_val
+        deficit_test = target_test - count_test
+        if deficit_train >= deficit_val and deficit_train >= deficit_test:
+            train_clusters.append(cluster_id)
+            count_train += size
+        elif deficit_val >= deficit_test:
+            val_clusters.append(cluster_id)
+            count_val += size
+        else:
+            test_clusters.append(cluster_id)
+            count_test += size
+
+    train_loc_mask = np.isin(clusters, train_clusters)
+    val_loc_mask = np.isin(clusters, val_clusters)
+    test_loc_mask = np.isin(clusters, test_clusters)
+
+    # Sanity checks: every location assigned, no cluster in multiple splits.
+    assert train_loc_mask.sum() + val_loc_mask.sum() + test_loc_mask.sum() == n_unique
+    assert len(set(train_clusters) & set(val_clusters)) == 0
+    assert len(set(train_clusters) & set(test_clusters)) == 0
+    assert len(set(val_clusters) & set(test_clusters)) == 0
+
+    print(
+        f"  Split (locations): train={train_loc_mask.sum()}, "
+        f"val={val_loc_mask.sum()}, test={test_loc_mask.sum()}"
+    )
+
+    # Propagate location-level split assignments back to all rows by (lat, lon).
+    train_latlon = set(
+        zip(unique_locs.loc[train_loc_mask, "lat"], unique_locs.loc[train_loc_mask, "lon"])
+    )
+    val_latlon = set(
+        zip(unique_locs.loc[val_loc_mask, "lat"], unique_locs.loc[val_loc_mask, "lon"])
+    )
+    test_latlon = set(
+        zip(unique_locs.loc[test_loc_mask, "lat"], unique_locs.loc[test_loc_mask, "lon"])
+    )
+    row_latlon = list(zip(df["lat"], df["lon"]))
+    train_mask = np.array([ll in train_latlon for ll in row_latlon])
+    val_mask = np.array([ll in val_latlon for ll in row_latlon])
+    test_mask = np.array([ll in test_latlon for ll in row_latlon])
+
+    assert train_mask.sum() + val_mask.sum() + test_mask.sum() == n_total, (
+        "Not all rows were assigned to a split — check for (lat, lon) values that "
+        "don't match any unique location after deduplication."
+    )
+
+    name_locs = df["name_loc"].reset_index(drop=True)
+    return {
+        "train_indices": name_locs[train_mask].reset_index(drop=True),
+        "val_indices": name_locs[val_mask].reset_index(drop=True),
+        "test_indices": name_locs[test_mask].reset_index(drop=True),
+        "clusters": clusters,
+    }
+
+
+def generate_splits(
+    data_dir: str,
+    distances_km: list[int] | None = None,
+    seed: int = SEED,
+) -> None:
+    """Generate and save spatial-cluster split files for the requested distances.
+
+    :param data_dir: root data directory (same as `paths.data_dir` in configs)
+    :param distances_km: list of DBSCAN cluster distances in kilometres; None
+        uses DEFAULT_DISTANCES_KM
+    :param seed: random seed for GroupShuffleSplit
+    """
+    if distances_km is None:
+        distances_km = DEFAULT_DISTANCES_KM
+
+    dataset_dir = Path(data_dir) / DATASET_NAME
+    csv_path = dataset_dir / MODEL_READY_CSV
+    splits_dir = dataset_dir / "splits"
+
+    if not csv_path.exists():
+        raise FileNotFoundError(f"Model-ready CSV not found: {csv_path}")
+
+    splits_dir.mkdir(parents=True, exist_ok=True)
+
+    df = pd.read_csv(csv_path)
+    for col in ("lat", "lon", "name_loc"):
+        if col not in df.columns:
+            raise ValueError(f"CSV must contain a '{col}' column")
+
+    print(f"Loaded {len(df)} rows from {csv_path}")
+
+    for dist_km in distances_km:
+        dist_m = dist_km * 1000
+        print(f"\nGenerating spatial split at {dist_km} km ({dist_m} m)...")
+
+        split = make_spatial_split(df, distance_m=dist_m, seed=seed)
+        n_train = len(split["train_indices"])
+        n_val = len(split["val_indices"])
+        n_test = len(split["test_indices"])
+
+        out_name = f"split_spatial_{dist_km}km.pth"
+        out_path = splits_dir / out_name
+        torch.save(split, out_path)
+
+        print(
+            f"  Saved {out_name}  "
+            f"(train={n_train}, val={n_val}, test={n_test}, "
+            f"total={n_train + n_val + n_test}/{len(df)})"
+        )
+        log.info(
+            f"  {dist_km}km: train={n_train}, val={n_val}, test={n_test} -> {out_name}"
+        )
+
+
+def main() -> None:
+    logging.basicConfig(level=logging.INFO, format="%(message)s")
+
+    parser = argparse.ArgumentParser(
+        description="Generate spatial-cluster split files for yield_africa.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=__doc__,
+    )
+    parser.add_argument(
+        "--data_dir",
+        type=str,
+        default="data/",
+        help="Root data directory (same as paths.data_dir in configs). Default: data/",
+    )
+    parser.add_argument(
+        "--distance_km",
+        type=int,
+        nargs="+",
+        default=None,
+        metavar="KM",
+        help=(
+            "Cluster distance threshold(s) in km. "
+            f"Omit to generate the default set: {DEFAULT_DISTANCES_KM} km."
+        ),
+    )
+    parser.add_argument(
+        "--seed",
+        type=int,
+        default=SEED,
+        help=f"Random seed for GroupShuffleSplit. Default: {SEED}",
+    )
+    args = parser.parse_args()
+
+    distances = args.distance_km  # None means use defaults
+    print(
+        f"Generating spatial splits  data_dir={args.data_dir}  "
+        f"distances_km={distances or DEFAULT_DISTANCES_KM}  seed={args.seed}"
+    )
+    generate_splits(
+        data_dir=args.data_dir,
+        distances_km=distances,
+        seed=args.seed,
+    )
+    print("\nDone.")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/models/components/loss_fns/rrmse_loss.py
+++ b/src/models/components/loss_fns/rrmse_loss.py
@@ -1,0 +1,44 @@
+from typing import Dict, override
+
+import torch
+
+from src.models.components.loss_fns.base_loss_fn import BaseLossFn
+
+
+class RRMSELoss(BaseLossFn):
+    """Relative Root Mean Squared Error (RRMSE).
+
+    RRMSE = RMSE / mean(|labels|)
+
+    Normalises RMSE by the mean absolute value of the target, giving a
+    unit-free percentage error. This makes results comparable across crops
+    and regions with different absolute yield scales (e.g. t/ha ranges
+    differ significantly between maize in Zambia and rice in Rwanda).
+
+    Returns a fraction (e.g. 0.15 = 15 % error). Multiply by 100 for
+    percentage when reporting.
+    """
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.criterion = torch.nn.MSELoss()
+        self.name = "rrmse_loss"
+
+    @override
+    def forward(
+        self,
+        pred: torch.Tensor,
+        labels: torch.Tensor | None = None,
+        batch: Dict[str, torch.Tensor] | None = None,
+        **kwargs,
+    ) -> torch.Tensor | Dict[str, torch.Tensor]:
+
+        labels = labels if labels is not None else batch.get("target")
+        rmse = torch.sqrt(self.criterion(pred, labels))
+        mean_abs = torch.mean(torch.abs(labels))
+        loss = rmse / (mean_abs + 1e-8)
+
+        if "return_label" in kwargs:
+            return {self.name: loss}
+        else:
+            return loss

--- a/tests/test_yield_africa.py
+++ b/tests/test_yield_africa.py
@@ -46,11 +46,16 @@ MOCK_AUX_COLS = {
 }
 
 MOCK_N_ROWS = 10
-# feat_year (1) + feat_country_{code} (8) are injected by YieldAfricaDataset
-# when country and year columns are present, so the effective tabular dim grows.
+# YieldAfricaDataset injects extra feat_* columns when country and year columns
+# are present: feat_year (1) + feat_country_{code} (8) + Fourier harmonics (6).
 from src.data.yield_africa_dataset import _ALL_COUNTRIES
-MOCK_INJECTED_FEAT_NAMES = {"feat_year"} | {f"feat_country_{c}" for c in _ALL_COUNTRIES}
-MOCK_TABULAR_DIM = len(MOCK_FEAT_COLS) + len(MOCK_INJECTED_FEAT_NAMES)  # 8 + 9 = 17
+MOCK_INJECTED_FEAT_NAMES = (
+    {"feat_year"}
+    | {f"feat_country_{c}" for c in _ALL_COUNTRIES}
+    | {"feat_lat_sin1", "feat_lat_cos1", "feat_lat_sin2", "feat_lat_cos2",
+       "feat_lon_sin1", "feat_lon_cos1"}
+)
+MOCK_TABULAR_DIM = len(MOCK_FEAT_COLS) + len(MOCK_INJECTED_FEAT_NAMES)  # 8 + 15 = 23
 MOCK_N_AUX = len(MOCK_AUX_COLS)          # 4
 
 


### PR DESCRIPTION
  Spatial-cluster split strategy for crop yield experiments

  - Adds a spatial-cluster split script and Hydra configs so that yield_africa experiments can be evaluated on geographically unseen locations,  alongside the existing random and LOCO split strategies
  - Speeds up DBSCAN clustering in BaseDataModule by replacing a slow Python geodesic lambda with sklearn's built-in haversine metric and BallTree index

A random 70/15/15 split for yield_africa allows nearby fields, and the same field across different years, to appear in both train and test. Because agricultural yield is strongly spatially autocorrelated (shared soils, rainfall patterns, agro-ecological zones), this inflates apparent generalisation performance. The spatial-cluster split closes this loophole by ensuring that no two geographically close locations straddle a split boundary.

