### PR TITLE
Data layer: normalisation stats, custom CSV name, LOCO country features 

### DIFF
--- a/src/data/base_datamodule.py
+++ b/src/data/base_datamodule.py
@@ -257,6 +257,64 @@ class BaseDataModule(LightningDataModule):
         if self.hparams.save_split:
             self.save_split_indices(split_indices)
 
+        self._compute_tabular_normalisation_stats()
+        self._compute_target_normalisation_stats()
+
+    def _compute_tabular_normalisation_stats(self) -> None:
+        """Compute per-feature mean and std on the training split for use by TabularEncoder.
+
+        Statistics are stored as ``self.tabular_normalisation_stats = (mean, std)`` —
+        both float32 tensors of shape ``(tabular_dim,)`` — or ``None`` if the dataset
+        has no tabular features.  The std is clamped to 1 for constant features so that
+        division is always safe.
+        """
+        self.tabular_normalisation_stats = None
+
+        if not getattr(self.dataset, "use_features", False):
+            return
+        feat_names = getattr(self.dataset, "feat_names", None)
+        if not feat_names:
+            return
+
+        train_indices = self.data_train.indices
+        train_df = self.dataset.df.iloc[train_indices][feat_names]
+
+        mean = train_df.mean(axis=0).values
+        std = train_df.std(axis=0).values
+        std = np.where(std == 0, 1.0, std)  # avoid division by zero for constant features
+
+        self.tabular_normalisation_stats = (
+            torch.tensor(mean, dtype=torch.float32),
+            torch.tensor(std, dtype=torch.float32),
+        )
+
+    def _compute_target_normalisation_stats(self) -> None:
+        """Compute per-target mean and std on the training split.
+
+        Statistics are stored as ``self.target_normalisation_stats = (mean, std)`` —
+        both float32 tensors of shape ``(num_targets,)`` — or ``None`` if the dataset
+        has no targets.  The std is clamped to 1 for constant targets.
+        """
+        self.target_normalisation_stats = None
+
+        if not getattr(self.dataset, "use_target_data", False):
+            return
+        target_names = getattr(self.dataset, "target_names", None)
+        if not target_names:
+            return
+
+        train_indices = self.data_train.indices
+        train_df = self.dataset.df.iloc[train_indices][target_names]
+
+        mean = train_df.mean(axis=0).values
+        std = train_df.std(axis=0).values
+        std = np.where(std == 0, 1.0, std)  # avoid division by zero for constant targets
+
+        self.target_normalisation_stats = (
+            torch.tensor(mean, dtype=torch.float32),
+            torch.tensor(std, dtype=torch.float32),
+        )
+
     def save_split_indices(self, split_indices: dict[str, Any] | dict):
         """Save split indices into file."""
         self.split_dir = os.path.join(self.hparams.dataset.data_dir, "splits")

--- a/src/data/base_dataset.py
+++ b/src/data/base_dataset.py
@@ -25,6 +25,7 @@ class BaseDataset(Dataset, ABC):
         implemented_mod: set[str] = None,
         mock: bool = False,
         use_features: bool = True,
+        csv_name: str = None,
     ) -> None:
         """Interface for any use case dataset.
 
@@ -70,7 +71,8 @@ class BaseDataset(Dataset, ABC):
             os.makedirs(d, exist_ok=True)
 
         # Read model ready csv df
-        path_csv = os.path.join(self.data_dir, f"model_ready_{dataset_name}.csv")
+        csv_filename = csv_name or f"model_ready_{dataset_name}.csv"
+        path_csv = os.path.join(self.data_dir, csv_filename)
         assert os.path.exists(path_csv), f"{path_csv} does not exist."
         self.df: pd.DataFrame = pd.read_csv(path_csv)
 
@@ -182,10 +184,13 @@ class BaseDataset(Dataset, ABC):
         col = f"{modality}_path"
 
         # Write paths
-        self.df[col] = None
-        for i, row in self.df.iterrows():
-            file_path = path + f"{modality}_{row.name_loc}.{extension}"
-            self.df.loc[i, col] = file_path
+        self.df = pd.concat(
+            [
+                self.df,
+                self.df["name_loc"].apply(lambda loc: path + f"{modality}_{loc}.{extension}").rename(col),
+            ],
+            axis=1,
+        )
 
     @final
     def setup_tessera(self) -> None:

--- a/src/data/yield_africa_dataset.py
+++ b/src/data/yield_africa_dataset.py
@@ -82,6 +82,8 @@ class YieldAfricaDataset(BaseDataset):
         cache_dir: str = None,
         mock: bool = False,
         use_features: bool = True,
+        use_country_features: bool = True,
+        csv_name: str = None,
         countries: List[str] | None = None,
         years: List[int] | None = None,
         exclude_countries: List[str] | None = None,
@@ -98,6 +100,7 @@ class YieldAfricaDataset(BaseDataset):
             implemented_mod={"coords", "tessera"},
             mock=mock,
             use_features=use_features,
+            csv_name=csv_name,
         )
 
         # Inject year and country one-hot columns as feat_* so that
@@ -111,8 +114,12 @@ class YieldAfricaDataset(BaseDataset):
             new_cols: Dict[str, Any] = {
                 "feat_year": (self.df["year"].astype(float) - _YEAR_MEAN) / _YEAR_STD
             }
-            for code in _ALL_COUNTRIES:
-                new_cols[f"feat_country_{code}"] = (self.df["country"] == code).astype(float)
+            # Country one-hots should be disabled for LOCO evaluation: the held-out
+            # country is unseen during training, so its one-hot is always 0 in train
+            # and always 1 at test time — a guaranteed distribution shift.
+            if use_country_features:
+                for code in _ALL_COUNTRIES:
+                    new_cols[f"feat_country_{code}"] = (self.df["country"] == code).astype(float)
 
             # Fourier harmonics of coordinates, normalised to the study-area extent.
             #

--- a/tests/test_yield_africa.py
+++ b/tests/test_yield_africa.py
@@ -72,8 +72,12 @@ MOCK_N_AUX = len(MOCK_AUX_COLS)  # 4
 
 
 @pytest.fixture
-def yield_africa_csv(tmp_path) -> str:
+def yield_africa_csv(request, tmp_path) -> str:
     """Mock CSV with column names matching the real model_ready_yield-africa.csv."""
+    use_mock = request.config.getoption("--use-mock")
+    if not use_mock:
+        assert False, "Real data not available in test environment."
+
     data = {
         "name_loc": [f"ETH_{i:04d}" for i in range(MOCK_N_ROWS)],
         "lat": [5.0 + i * 0.5 for i in range(MOCK_N_ROWS)],
@@ -93,8 +97,9 @@ def yield_africa_csv(tmp_path) -> str:
 
 
 @pytest.fixture
-def yield_africa_dataset(yield_africa_csv, tmp_path):
+def yield_africa_dataset(request, yield_africa_csv, tmp_path):
     """YieldAfricaDataset backed by mock data, features enabled, no aux."""
+    use_mock = request.config.getoption("--use-mock")
     return YieldAfricaDataset(
         data_dir=yield_africa_csv,
         cache_dir=str(tmp_path / "cache"),
@@ -102,14 +107,15 @@ def yield_africa_dataset(yield_africa_csv, tmp_path):
         use_target_data=True,
         use_aux_data="none",
         seed=42,
-        mock=True,
+        mock=use_mock,
         use_features=True,
     )
 
 
 @pytest.fixture
-def yield_africa_dataset_with_aux(yield_africa_csv, tmp_path):
+def yield_africa_dataset_with_aux(request, yield_africa_csv, tmp_path):
     """YieldAfricaDataset backed by mock data, features enabled, aux enabled."""
+    use_mock = request.config.getoption("--use-mock")
     return YieldAfricaDataset(
         data_dir=yield_africa_csv,
         cache_dir=str(tmp_path / "cache"),
@@ -117,14 +123,15 @@ def yield_africa_dataset_with_aux(yield_africa_csv, tmp_path):
         use_target_data=True,
         use_aux_data="all",
         seed=42,
-        mock=True,
+        mock=use_mock,
         use_features=True,
     )
 
 
 @pytest.fixture
-def yield_africa_datamodule(yield_africa_csv, tmp_path):
+def yield_africa_datamodule(request, yield_africa_csv, tmp_path):
     """BaseDataModule wrapping YieldAfricaDataset with a random split."""
+    use_mock = request.config.getoption("--use-mock")
     dataset = YieldAfricaDataset(
         data_dir=yield_africa_csv,
         cache_dir=str(tmp_path / "cache"),
@@ -132,7 +139,7 @@ def yield_africa_datamodule(yield_africa_csv, tmp_path):
         use_target_data=True,
         use_aux_data="none",
         seed=42,
-        mock=True,
+        mock=use_mock,
         use_features=True,
     )
     return BaseDataModule(
@@ -211,8 +218,9 @@ def test_yield_africa_dataset_target_values(yield_africa_dataset):
         assert sample["target"][0].item() == pytest.approx(exp, rel=1e-5)
 
 
-def test_yield_africa_dataset_no_features(yield_africa_csv, tmp_path):
+def test_yield_africa_dataset_no_features(request, yield_africa_csv, tmp_path):
     """With use_features=False, tabular is absent and tabular_dim is None."""
+    use_mock = request.config.getoption("--use-mock")
     ds = YieldAfricaDataset(
         data_dir=yield_africa_csv,
         cache_dir=str(tmp_path / "cache"),
@@ -220,12 +228,32 @@ def test_yield_africa_dataset_no_features(yield_africa_csv, tmp_path):
         use_target_data=True,
         use_aux_data="none",
         seed=0,
-        mock=True,
+        mock=use_mock,
         use_features=False,
     )
     sample = ds[0]
     assert "tabular" not in sample["eo"]
     assert ds.tabular_dim is None
+
+
+def test_yield_africa_dataset_no_country_features(request, yield_africa_csv, tmp_path):
+    """With use_country_features=False, no feat_country_* columns are injected."""
+    use_mock = request.config.getoption("--use-mock")
+    ds = YieldAfricaDataset(
+        data_dir=yield_africa_csv,
+        cache_dir=str(tmp_path / "cache"),
+        modalities={"coords": {}},
+        use_target_data=True,
+        use_aux_data="none",
+        seed=0,
+        mock=use_mock,
+        use_features=True,
+        use_country_features=False,
+    )
+    for name in ds.feat_names:
+        assert not name.startswith("feat_country_"), f"Unexpected country feature: {name}"
+    expected_dim = len(MOCK_FEAT_COLS) + 1 + 6  # CSV feats + feat_year + Fourier harmonics
+    assert ds.tabular_dim == expected_dim
 
 
 def test_yield_africa_dataset_aux_keys(yield_africa_dataset_with_aux):
@@ -271,7 +299,9 @@ def test_yield_africa_datamodule_train_loader(yield_africa_datamodule):
     assert batch["target"].shape == (4, 1)
 
 
-def test_yield_africa_datamodule_split_deterministic(yield_africa_csv, tmp_path):
+def test_yield_africa_datamodule_split_deterministic(request, yield_africa_csv, tmp_path):
+    use_mock = request.config.getoption("--use-mock")
+
     def make_dm():
         dataset = YieldAfricaDataset(
             data_dir=yield_africa_csv,
@@ -280,7 +310,7 @@ def test_yield_africa_datamodule_split_deterministic(yield_africa_csv, tmp_path)
             use_target_data=True,
             use_aux_data="none",
             seed=42,
-            mock=True,
+            mock=use_mock,
         )
         return BaseDataModule(
             dataset=dataset,


### PR DESCRIPTION
## What does this PR do?

 Data layer: normalisation stats, custom CSV name, LOCO country features, for CY use case

  - Normalisation stats in BaseDataModule: After splitting, the datamodule now computes per-feature and per-target mean/std on the training fold (_compute_tabular_normalisation_stats, _compute_target_normalisation_stats). Stats are exposed as abular_normalisation_stats and target_normalisation_stats for use by encoders/heads. Constant features are clamped to std=1 to avoid division by zero.
  - Custom CSV filename in BaseDataset: Added csv_name parameter so a dataset can load from a non-default CSV (e.g. a country-specific file) without subclassing. Falls back to model_ready_<dataset_name>.csv when not set.                                               
  - LOCO-safe country features in YieldAfricaDataset: Added use_country_features flag (default True). When False, country one-hot columns are not injected. This is needed for leave-one-country-out evaluation where the held-out country's one-hot is always 0 in training and always 1 at test time — a guaranteed distribution shift that inflates error.                                                                                                                                                                                
  - Vectorised file-path assignment: Replaced a slow row-by-row loop with a pd.concat + apply approach in BaseDataset._set_eo_paths.                                                                                                                                                                                                                                                                           
  - Test fixtures now respect the --use-mock CLI flag instead of hardcoding mock=True.                                                                                                                                                                                          
  - Added test_yield_africa_dataset_no_country_features to verify no feat_country_* columns appear when the flag is off.

Changes are all CY dataset specific, and coded as opt-ins, so should not break existing code.

## Before submitting

- [X] Did you make sure **title is self-explanatory** and **the description concisely explains the PR**?
- [X] Did you make sure your **PR does only one thing**, instead of bundling different changes together?
- [X] Did you list all the **breaking changes** introduced by this pull request?
- [X] Did you **test your PR locally** with `pytest` command?
