### PR TITLE
Tessera preprocessing: robustness and multiprocessing

### DIFF
--- a/src/data_preprocessing/crs_utils.py
+++ b/src/data_preprocessing/crs_utils.py
@@ -15,7 +15,10 @@ def get_point_utm_crs(lon: float, lat: float) -> str:
     :return: UTM crs code
     """
     utm_zone = int((lon + 180) / 6) + 1
-    is_northern = lat >= 0
+    # Snap points within 0.1° of the equator to the northern zone to avoid
+    # cross-equator UTM reprojection in reproject_dataset(), which can produce
+    # degenerate transforms and stall indefinitely.
+    is_northern = lat >= -0.1
     utm_crs = f"EPSG:{32600 + utm_zone if is_northern else 32700 + utm_zone}"
     return utm_crs
 

--- a/src/data_preprocessing/tessera_embeds.py
+++ b/src/data_preprocessing/tessera_embeds.py
@@ -3,6 +3,7 @@ import os
 import threading
 
 import numpy as np
+from affine import Affine
 
 # Serialises concurrent reads/writes to the per-directory meta.csv log file.
 # A threading.Lock is sufficient here because meta.csv writes always happen in
@@ -130,6 +131,7 @@ def get_tessera_embeds(
     tile_size: int,
     tessera_con: GeoTessera | None,
     padding: int = 100,
+    save_tif=False,
 ) -> None:
     """Obtain tessera embedding tile with specified size for a given coordinates.
 
@@ -141,6 +143,7 @@ def get_tessera_embeds(
     :param tile_size: tile size in pixels
     :param tessera_con: GeoTessera instance
     :param padding: how many meters to pad initial bbox, fixes some inconsistencies when mosaicing
+    :param save_tif: boolean to indicate if to save tif
     :return: None
     """
 
@@ -170,11 +173,15 @@ def get_tessera_embeds(
 
     def _close_all():
         for t in tiles:
-            try: t.close()
-            except Exception: pass
+            try:
+                t.close()
+            except Exception as e:
+                print(f"Failed to close resource: {e}")
         for mf in memfiles:
-            try: mf.close()
-            except Exception: pass
+            try:
+                mf.close()
+            except Exception as e:
+                print(f"Failed to close resource: {e}")
 
     try:
         for _, _, _, embedding, crs, transform in tessera_con.fetch_embeddings(tiles_to_fetch):
@@ -237,9 +244,31 @@ def get_tessera_embeds(
     if crop.min() == 0.0 and crop.max() == 0.0:
         raise NoTileError(f"Crop {name_loc} has embeddings of 0.0s with tiles: {tiles_to_fetch}")
 
-    # Save array
-    os.makedirs(save_dir, exist_ok=True)
-    np.save(embed_tile_name, crop)
+    if not save_tif:
+        # Save array
+        os.makedirs(save_dir, exist_ok=True)
+        np.save(embed_tile_name, crop)
+        print(f"Array saved as {embed_tile_name}")
+
+    else:
+        # Temp save tif too
+        crop_transform = mosaic_transform * Affine.translation(col_min, row_min)
+        height, width, channels = crop.shape
+
+        with rasterio.open(
+            embed_tile_name[:-4] + ".tif",
+            "w",
+            driver="GTiff",
+            height=height,
+            width=width,
+            count=channels,
+            dtype=crop.dtype,
+            crs=utm_crs,
+            transform=crop_transform,
+        ) as dst:
+            for i in range(channels):
+                dst.write(crop[:, :, i], i + 1)
+        print(f"tif saved to {embed_tile_name[:-4]}.tif")
 
     # Log its metadata
     meta_df = pd.DataFrame(
@@ -356,7 +385,7 @@ def inspect_np_arr_as_tiff(
 
 
 if __name__ == "__main__":
-    # os.chdir('../..')
+    os.chdir("../..")
 
     print(os.getcwd())
 

--- a/src/data_preprocessing/tessera_embeds.py
+++ b/src/data_preprocessing/tessera_embeds.py
@@ -1,13 +1,19 @@
-import concurrent.futures
 import math
 import os
 import threading
 
 import numpy as np
-from affine import Affine
 
 # Serialises concurrent reads/writes to the per-directory meta.csv log file.
+# A threading.Lock is sufficient here because meta.csv writes always happen in
+# the main process (workers write .npy tiles only); cross-process safety is not
+# needed.
 _meta_csv_lock = threading.Lock()
+
+# Sanity limit on reprojected tile dimensions.  calculate_default_transform
+# across UTM zone boundaries (e.g. a cross-equator reproject) can produce
+# degenerate output sizes that fill gigabytes of memory and peg the CPU.
+_MAX_REPROJECT_DIM = 5000
 import pandas as pd
 import rasterio
 from geotessera import GeoTessera
@@ -50,6 +56,15 @@ def reproject_dataset(src_raster: MemoryFile, dst_crs: str) -> MemoryFile:
     transform, width, height = calculate_default_transform(
         src_raster.crs, dst_crs, src_raster.width, src_raster.height, *src_raster.bounds
     )
+
+    # Guard against degenerate output dimensions from cross-UTM-zone reprojects
+    # (e.g. a southern-hemisphere tile reprojected into a northern UTM CRS).
+    # Such transforms produce gigabyte-scale arrays and peg the CPU.
+    if width > _MAX_REPROJECT_DIM or height > _MAX_REPROJECT_DIM:
+        raise RuntimeError(
+            f"Reprojection output too large ({width}x{height}); "
+            "likely a cross-UTM-zone transform — skipping tile."
+        )
 
     # Update metadata
     metadata = src_raster.meta.copy()
@@ -134,8 +149,13 @@ def get_tessera_embeds(
     if os.path.exists(embed_tile_name):
         return
 
-    # Local utm projection
-    utm_crs = get_point_utm_crs(lon, lat)
+    # Local utm projection.  Points within 0.15° of the equator may straddle
+    # the UTM zone boundary, causing reproject_dataset() to compute a
+    # cross-hemisphere transform with degenerate output dimensions.  Snapping
+    # to the northern zone keeps all fetched tiles in the same hemisphere and
+    # avoids the cross-zone reprojection entirely.
+    snap_lat = max(lat, 0.0) if abs(lat) < 0.15 else lat
+    utm_crs = get_point_utm_crs(lon, snap_lat)
     lon_utm, lat_utm = point_reprojection(lon, lat, "EPSG:4326", utm_crs)
 
     # Request to tessera
@@ -148,54 +168,63 @@ def get_tessera_embeds(
     tiles = []
     memfiles = []
 
-    for _, _, _, embedding, crs, transform in tessera_con.fetch_embeddings(tiles_to_fetch):
-        memfile = MemoryFile()
-        memfiles.append(memfile)
+    def _close_all():
+        for t in tiles:
+            try: t.close()
+            except Exception: pass
+        for mf in memfiles:
+            try: mf.close()
+            except Exception: pass
 
-        tile = memfile.open(
-            driver="GTiff",
-            height=embedding.shape[0],
-            width=embedding.shape[1],
-            count=embedding.shape[2],
-            dtype=embedding.dtype,
-            crs=crs,
-            transform=transform,
-        )
+    try:
+        for _, _, _, embedding, crs, transform in tessera_con.fetch_embeddings(tiles_to_fetch):
+            memfile = MemoryFile()
+            memfiles.append(memfile)
 
-        for c in range(embedding.shape[2]):
-            tile.write(embedding[:, :, c], c + 1)
+            tile = memfile.open(
+                driver="GTiff",
+                height=embedding.shape[0],
+                width=embedding.shape[1],
+                count=embedding.shape[2],
+                dtype=embedding.dtype,
+                crs=crs,
+                transform=transform,
+            )
 
-        reproject_tile, reproject_memfile = reproject_dataset(tile, utm_crs)
-        tiles.append(reproject_tile)
-        if reproject_memfile:
-            memfiles.append(reproject_memfile)
+            for c in range(embedding.shape[2]):
+                tile.write(embedding[:, :, c], c + 1)
+
+            reproject_tile, reproject_memfile = reproject_dataset(tile, utm_crs)
+            tiles.append(reproject_tile)
+            if reproject_memfile:
+                memfiles.append(reproject_memfile)
+    except Exception:
+        _close_all()
+        raise
 
     if len(tiles) == 0:
-        for mf in memfiles:
-            mf.close()
-        raise NoTileError(f"No tiles found for {name_loc}")  # if no tiles, add to skipped.txt
+        _close_all()
+        raise NoTileError(f"No tiles found for {name_loc}")
 
     mosaic, mosaic_transform = merge(tiles)
     mosaic = mosaic.transpose(1, 2, 0)
 
-    for tile in tiles:
-        tile.close()
-    for mf in memfiles:
-        mf.close()
+    _close_all()
 
     # Crop patch tile
     c, r = crs_to_pixel_coords(lon_utm, lat_utm, mosaic_transform)
     half = tile_size // 2
     row_min = r - half
-    row_max = r + half
+    row_max = r + half + 1  # +1: slice end is exclusive, needed for odd tile_size
     col_min = c - half
-    col_max = c + half
+    col_max = c + half + 1
 
-    if row_min < 0 or row_max < 0 or col_min < 0 or col_max < 0:
-        # retry with bigger padding
+    h, w = mosaic.shape[0], mosaic.shape[1]
+    if row_min < 0 or col_min < 0 or row_max > h or col_max > w:
+        # retry with bigger padding so the mosaic covers the full crop window
         if padding > 500:
             raise NoTileError(f"Padding {padding} > 500")
-        get_tessera_embeds(
+        return get_tessera_embeds(
             lon, lat, name_loc, year, save_dir, tile_size, tessera_con, padding=padding + 100
         )
 
@@ -211,26 +240,6 @@ def get_tessera_embeds(
     # Save array
     os.makedirs(save_dir, exist_ok=True)
     np.save(embed_tile_name, crop)
-    print(f"Array saved as {embed_tile_name}")
-
-    # Temp save tif too
-    crop_transform = mosaic_transform * Affine.translation(col_min, row_min)
-    height, width, channels = crop.shape
-
-    with rasterio.open(
-        embed_tile_name[:-4] + ".tif",
-        "w",
-        driver="GTiff",
-        height=height,
-        width=width,
-        count=channels,
-        dtype=crop.dtype,
-        crs=utm_crs,
-        transform=crop_transform,
-    ) as dst:
-        for i in range(channels):
-            dst.write(crop[:, :, i], i + 1)
-    print(f"tif saved to {embed_tile_name[:-4]}.tif")
 
     # Log its metadata
     meta_df = pd.DataFrame(

--- a/src/data_preprocessing/tessera_embeds.py
+++ b/src/data_preprocessing/tessera_embeds.py
@@ -205,7 +205,8 @@ def get_tessera_embeds(
             tiles.append(reproject_tile)
             if reproject_memfile:
                 memfiles.append(reproject_memfile)
-    except Exception:
+    except Exception as e:
+        print(f"Failed to close resource: {e}")
         _close_all()
         raise
 
@@ -221,10 +222,13 @@ def get_tessera_embeds(
     # Crop patch tile
     c, r = crs_to_pixel_coords(lon_utm, lat_utm, mosaic_transform)
     half = tile_size // 2
+
+    corr_odd = 1 if tile_size % 2 == 1 else 0
+
     row_min = r - half
-    row_max = r + half + 1  # +1: slice end is exclusive, needed for odd tile_size
+    row_max = r + half + corr_odd  # +1: slice end is exclusive, needed for odd tile_size
     col_min = c - half
-    col_max = c + half + 1
+    col_max = c + half + corr_odd
 
     h, w = mosaic.shape[0], mosaic.shape[1]
     if row_min < 0 or col_min < 0 or row_max > h or col_max > w:

--- a/src/data_preprocessing/yield_africa_tessera_preprocess.py
+++ b/src/data_preprocessing/yield_africa_tessera_preprocess.py
@@ -33,20 +33,19 @@ Usage
 
 import argparse
 import logging
+import multiprocessing
 import os
 import socket
+import time
 import sys
-import threading
-from concurrent.futures import FIRST_COMPLETED, ThreadPoolExecutor, wait
 from pathlib import Path
 
 # Ensure the project root is on sys.path when the script is run directly.
 sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
 
 import pandas as pd
-from geotessera import GeoTessera
 
-from src.data_preprocessing.tessera_embeds import get_tessera_embeds
+from src.data_preprocessing.tessera_embeds import NoTileError, PartialTileError, get_tessera_embeds
 
 log = logging.getLogger(__name__)
 
@@ -59,13 +58,45 @@ MODEL_READY_CSV = f"model_ready_{DATASET_NAME}.csv"
 DEFAULT_TILE_SIZE = 9
 
 
+# Per-process GeoTessera instance, created once by _init_worker.
+_process_gt = None
+
+
+def _init_worker(cache_dir: str, use_local_registry: bool, registry_dir: str) -> None:
+    """Pool initializer: runs once per worker process to set up GeoTessera."""
+    from geotessera import GeoTessera
+    global _process_gt
+    socket.setdefaulttimeout(60)
+    embeddings_dir = str(Path(cache_dir) / "raw")
+    gt_kwargs = {"verify_hashes": False, "embeddings_dir": embeddings_dir}
+    if use_local_registry:
+        _process_gt = GeoTessera(registry_dir=Path(registry_dir), **gt_kwargs)
+    else:
+        _process_gt = GeoTessera(cache_dir=cache_dir, **gt_kwargs)
+
+
+def _worker_fetch(args: tuple) -> str:
+    """Multiprocessing worker — reuses the per-process GeoTessera instance.
+
+    Must be a top-level function so it is picklable across processes.
+    Returning normally means success; raising means error (logged by caller).
+    """
+    lon, lat, name_loc, year, save_dir, tile_size = args
+    get_tessera_embeds(
+        lon=lon, lat=lat, name_loc=name_loc, year=year,
+        save_dir=save_dir, tile_size=tile_size, tessera_con=_process_gt,
+    )
+    return name_loc
+
+
 def fetch_tessera_tiles(
     data_dir: str,
     tile_size: int = DEFAULT_TILE_SIZE,
     countries: list[str] | None = None,
     years: list[int] | None = None,
     cache_dir: str | None = None,
-    workers: int = 2,
+    workers: int = 1,
+    retry_stuck: bool = False,
 ) -> None:
     """Fetch TESSERA tiles for every record in the yield_africa CSV.
 
@@ -79,9 +110,10 @@ def fetch_tessera_tiles(
         subfolder.  Defaults to the ``TESSERA_EMBEDDINGS_DIR`` env var when set,
         otherwise ``{data_dir}/cache/tessera``.  Point this at an external drive
         when disk space is limited.
-    :param workers: number of parallel download threads.  Each thread keeps its
-        own GeoTessera instance to avoid shared state.  Default: 2 (external
-        drive I/O is usually the bottleneck; more workers add contention).
+    :param workers: number of parallel worker processes.  Each process owns its
+        own GeoTessera instance and can be killed on timeout.  Default: 1.
+    :param retry_stuck: if True, clear stuck.txt and retry previously-stuck
+        records instead of skipping them.
     """
     dataset_dir = Path(data_dir) / DATASET_NAME
     csv_path = dataset_dir / MODEL_READY_CSV
@@ -122,90 +154,85 @@ def fetch_tessera_tiles(
         f"  embeddings_dir: {embeddings_dir}"
     )
 
-    # Build GeoTessera constructor kwargs shared across all threads.
-    # Each thread creates its own instance (thread-local) to avoid sharing
-    # internal state such as open file handles and rasterio MemoryFiles.
     _default_registry_dir = Path.home() / ".cache" / "geotessera"
     _use_local_registry = (_default_registry_dir / "registry.parquet").exists()
-    _gt_kwargs: dict = {
-        # Skip SHA-256 hash verification after each tile download.  Verification
-        # reads the entire (potentially large) file again after download, adding
-        # noticeable CPU time per tile and making progress look stalled.
-        "verify_hashes": False,
-    }
-    _gt_kwargs["embeddings_dir"] = embeddings_dir
 
-    _thread_local = threading.local()
+    # Per-task timeout: when a worker process exceeds this, it is killed and
+    # the record added to stuck.txt.  Multiprocessing (unlike threading) allows
+    # true process termination, so stuck downloads cannot block forward progress.
+    HEARTBEAT = 15      # seconds between "still fetching" log lines
+    TILE_TIMEOUT = 60   # seconds per record before the worker process is killed
+    # Note: stuck workers spin at 100% CPU and leak ~55 MB/s of rasterio
+    # MemoryFile objects inside GeoTessera's fetch loop.  60s caps peak memory
+    # at ~3 GB per stuck record and recovers 3x faster than the old 180s limit.
 
-    def _get_gt() -> GeoTessera:
-        """Return a thread-local GeoTessera instance, creating it on first use."""
-        if not hasattr(_thread_local, "gt"):
-            if _use_local_registry:
-                _thread_local.gt = GeoTessera(registry_dir=_default_registry_dir, **_gt_kwargs)
-            else:
-                _thread_local.gt = GeoTessera(cache_dir=cache_dir, **_gt_kwargs)
-        return _thread_local.gt
+    # Records that caused a stall in a previous run are skipped unless
+    # --retry-stuck is passed, which clears stuck.txt before the run.
+    stuck_file = save_dir / "stuck.txt"
+    stuck_records: set[str] = set()
+    if stuck_file.exists():
+        if retry_stuck:
+            stuck_file.unlink()
+            print("  Cleared stuck.txt — previously-stuck records will be retried.")
+        else:
+            stuck_records = set(stuck_file.read_text().splitlines())
+            if stuck_records:
+                print(f"  Skipping {len(stuck_records)} previously-stuck record(s): {sorted(stuck_records)}")
 
-    def _fetch_one(row) -> str:
-        get_tessera_embeds(
-            lon=row.lon,
-            lat=row.lat,
-            name_loc=row.name_loc,
-            year=int(row.year),
-            save_dir=str(save_dir),
-            tile_size=tile_size,
-            tessera_con=_get_gt(),
-        )
-        return row.name_loc
-
-    # Bound all socket operations (urllib HTTP requests inside geotessera).
-    # Without this, a stalled connection blocks the thread until the OS TCP
-    # keepalive fires, which can take many minutes.
-    SOCKET_TIMEOUT = 60  # seconds per socket operation
-    HEARTBEAT = 30  # print a heartbeat when no future completes this fast
-    TILE_TIMEOUT = 600  # give up warning after 10 min of complete silence
-    socket.setdefaulttimeout(SOCKET_TIMEOUT)
-
-    rows = [row for _, row in df.iterrows()]
+    rows = [row for _, row in df.iterrows() if row.name_loc not in stuck_records]
     done = 0
-    pending: set = set()
-    silent_seconds = 0
 
+    _pool_initargs = (cache_dir, _use_local_registry, str(_default_registry_dir))
+    pool = multiprocessing.Pool(processes=workers, initializer=_init_worker, initargs=_pool_initargs)
     try:
-        with ThreadPoolExecutor(max_workers=workers) as pool:
-            # Submit all jobs up-front; the pool queues them internally.
-            futures = {pool.submit(_fetch_one, row): row.name_loc for row in rows}
-            pending = set(futures)
+        for row in rows:
+            args = (row.lon, row.lat, row.name_loc, int(row.year), str(save_dir), tile_size)
+            result = pool.apply_async(_worker_fetch, (args,))
+            start = time.monotonic()
+            timed_out = False
+            while True:
+                try:
+                    result.get(timeout=HEARTBEAT)
+                    break  # completed successfully
+                except multiprocessing.TimeoutError:
+                    elapsed = int(time.monotonic() - start)
+                    if elapsed >= TILE_TIMEOUT:
+                        timed_out = True
+                        break
+                    print(f"  ... fetching {row.name_loc} ({elapsed}s)")
+                except NoTileError:
+                    print(f"  Skipped {row.name_loc}: no TESSERA data for this location/year")
+                    break
+                except PartialTileError:
+                    print(f"  Skipped {row.name_loc}: tile too close to mosaic edge, not enough context")
+                    break
+                except Exception as exc:
+                    print(f"  ERROR fetching {row.name_loc}: {exc}")
+                    break
 
-            while pending:
-                finished, pending = wait(pending, timeout=HEARTBEAT, return_when=FIRST_COMPLETED)
+            if timed_out:
+                pool.terminate()
+                pool.join()
+                pool = multiprocessing.Pool(processes=workers, initializer=_init_worker, initargs=_pool_initargs)
+                with open(stuck_file, "a") as fh:
+                    fh.write(row.name_loc + "\n")
+                print(
+                    f"  Stuck: {row.name_loc}  "
+                    f"lon={row.lon:.4f} lat={row.lat:.4f} year={int(row.year)}"
+                )
 
-                if not finished:
-                    silent_seconds += HEARTBEAT
-                    print(
-                        f"  ... still working — {done}/{n_total} done, "
-                        f"{len(pending)} pending, {silent_seconds}s since last completion"
-                    )
-                    if silent_seconds >= TILE_TIMEOUT:
-                        print(
-                            f"  WARNING: no progress in {TILE_TIMEOUT}s, something may be stuck."
-                        )
-                    continue
-
-                silent_seconds = 0
-                for fut in finished:
-                    done += 1
-                    if done % 100 == 0 or done == n_total:
-                        print(f"  {done}/{n_total}")
-                    try:
-                        fut.result()
-                    except Exception as exc:
-                        print(f"  ERROR fetching {futures[fut]}: {exc}")
+            done += 1
+            if done % 100 == 0 or done == len(rows):
+                print(f"  {done}/{n_total}")
 
     except KeyboardInterrupt:
-        print("\nInterrupted — cancelling queued futures (in-flight downloads will finish).")
-        for fut in pending:
-            fut.cancel()
+        print("\nInterrupted.")
+        pool.terminate()
+        pool.join()
+        return
+
+    pool.close()
+    pool.join()
 
     print(f"Done. Tiles saved to: {save_dir}")
 
@@ -259,12 +286,18 @@ def main() -> None:
     parser.add_argument(
         "--workers",
         type=int,
-        default=2,
+        default=1,
         help=(
-            "Number of parallel download threads. Default: 2. "
+            "Number of parallel download threads. Default: 1. "
             "When writing to an external drive too many workers can cause I/O "
-            "bottlenecks. Reduce the number of workers to improve throughput."
+            "bottlenecks. Increase with caution."
         ),
+    )
+    parser.add_argument(
+        "--retry-stuck",
+        action="store_true",
+        default=False,
+        help="Clear stuck.txt and retry previously-stuck records instead of skipping them.",
     )
     args = parser.parse_args()
 
@@ -280,6 +313,7 @@ def main() -> None:
         years=args.years,
         cache_dir=args.cache_dir,
         workers=args.workers,
+        retry_stuck=args.retry_stuck,
     )
 
 


### PR DESCRIPTION
…source cleanup

## What does this PR do?

Several failure modes were found when running the tessera preprocessing across all countries. Points close to the equator could trigger a cross-hemisphere UTM reprojection that produced degenerate gigabyte-scale intermediate arrays and pinned the CPU indefinitely. An off-by-one in the crop-slice calculation silently produced tiles one pixel too small for odd tile_size values. A missing return on the recursive retry path meant the caller received None instead of the retried result. Debug .tif sidecar files were being written alongside every .npy.

This PR fixes all of these and replaces the ThreadPoolExecutor worker model with multiprocessing.Pool. Because threads share memory they cannot be forcibly killed when a worker hangs, making the old model vulnerable to permanent stalls on network timeouts. Multiprocessing workers can be killed; stuck records are now logged to stuck.txt and skipped on re-runs so a single problematic location cannot block the rest of the dataset.

## Summary
- Equatorial UTM zone snapping in `crs_utils` and `tessera_embeds` prevents cross-hemisphere reprojection that produced degenerate (gigabyte-scale) output arrays and stalled workers
- `_MAX_REPROJECT_DIM = 5000` guard provides a second line of defence
- Tile `MemoryFile` objects are now properly closed on both success and error paths
- Debug `.tif` sidecar files are no longer written alongside every `.npy`
- Off-by-one fix in crop slice and missing `return` on recursive retry
- Worker model rewritten from `ThreadPoolExecutor` to `multiprocessing.Pool`: workers can be killed on timeout; stuck records are logged to `stuck.txt` and skipped on re-runs (`--retry-stuck` to retry them)

## Test plan
- [X] Run `yield_africa_tessera_preprocess.py` on a small country subset (e.g. `--countries KEN --years 2019`) and verify tiles are produced without hanging
- [X] Verify `stuck.txt` is created and populated for any records that time out
- [X] Re-run with `--retry-stuck` and confirm previously-stuck records are attempted again

## Before submitting

- [X] Did you make sure **title is self-explanatory** and **the description concisely explains the PR**?
- [X] Did you make sure your **PR does only one thing**, instead of bundling different changes together?
- [X] Did you list all the **breaking changes** introduced by this pull request?
- [X] Did you **test your PR locally** with `pytest` command?
