### PR TITLE
YieldAfrica dataset: drop records with missing tessera tiles

### DIFF
--- a/configs/data/yield_africa_tessera.yaml
+++ b/configs/data/yield_africa_tessera.yaml
@@ -11,6 +11,7 @@ dataset:
       format: npy
       # year is intentionally omitted: yield_africa fetches per-record year tiles
       # via the preprocessing script rather than a single bulk-year download.
+  csv_name: null
   use_target_data: true
   use_features: true
   use_aux_data: none

--- a/configs/data/yield_africa_tessera_KEN.yaml
+++ b/configs/data/yield_africa_tessera_KEN.yaml
@@ -5,7 +5,8 @@ dataset:
   data_dir: ${paths.data_dir}
   modalities:
     tessera:
-      # size must match the tile_size used when running the preprocessing script.
+      # size must match or be smaller than the tile_size used when running the
+      # preprocessing script.
       # Default: 9 pixels (set by yield_africa_tessera_preprocess.py --tile_size).
       size: 9
       format: npy

--- a/src/data/base_dataset.py
+++ b/src/data/base_dataset.py
@@ -188,7 +188,9 @@ class BaseDataset(Dataset, ABC):
         self.df = pd.concat(
             [
                 self.df,
-                self.df["name_loc"].apply(lambda loc: path + f"{modality}_{loc}.{extension}").rename(col),
+                self.df["name_loc"]
+                .apply(lambda loc: path + f"{modality}_{loc}.{extension}")
+                .rename(col),
             ],
             axis=1,
         )
@@ -310,7 +312,11 @@ class BaseDataset(Dataset, ABC):
         """Loads."""
         size = self.modalities["tessera"]["size"]
         arr = self.load_npy(filepath)
-        if arr.size()[1] != size:
+        if arr.size()[1] < size:
+            raise ValueError(
+                f"Requested tile size {size} is larger than actual available tile size {arr.size()[1]}"
+            )
+        elif arr.size()[1] != size:
             arr = center_crop_npy(arr, (128, size, size))
         # TODO any normalisation needed
         return arr

--- a/src/data/yield_africa_dataset.py
+++ b/src/data/yield_africa_dataset.py
@@ -180,6 +180,19 @@ class YieldAfricaDataset(BaseDataset):
         # self.feat_names and self.tabular_dim.
         self.records = self.get_records()
 
+        # Drop records whose TESSERA tile is absent so the model is never
+        # trained or evaluated on zero-padded stand-ins.
+        if "tessera" in self.modalities:
+            before = len(self.records)
+            self.records = [r for r in self.records if os.path.exists(r["tessera_path"])]
+            dropped = before - len(self.records)
+            if dropped:
+                log.warning(
+                    "Dropped %d/%d records: TESSERA tile not found on disk.",
+                    dropped,
+                    before,
+                )
+
     def setup(self) -> None:
         """Check for requested modality data; warn if TESSERA tiles are absent.
 
@@ -197,7 +210,7 @@ class YieldAfricaDataset(BaseDataset):
                 log.warning(
                     "TESSERA tiles not found at %s. "
                     "Run src/data_preprocessing/yield_africa_tessera_preprocess.py "
-                    "to pre-fetch tiles. Missing tiles will fall back to zero tensors.",
+                    "to pre-fetch tiles. Records with missing tiles are excluded from the dataset.",
                     tessera_dir,
                 )
 
@@ -212,15 +225,7 @@ class YieldAfricaDataset(BaseDataset):
                     [row["lat"], row["lon"]], dtype=torch.float32
                 )
             elif modality == "tessera":
-                tile_path = row["tessera_path"]
-                if os.path.exists(tile_path):
-                    sample["eo"]["tessera"] = self.load_npy(tile_path)
-                else:
-                    size = self.modalities["tessera"].get("size", 9)
-                    log.debug("TESSERA tile missing: %s — using zero fallback.", tile_path)
-                    sample["eo"]["tessera"] = torch.zeros(
-                        _TESSERA_CHANNELS, size, size, dtype=torch.float32
-                    )
+                sample["eo"]["tessera"] = self.load_tessera(row["tessera_path"])
 
         if self.use_features and self.feat_names:
             sample["eo"]["tabular"] = torch.tensor(


### PR DESCRIPTION
## What does this PR do?

Previously, when a tessera tile was absent from disk, __getitem__ silently returned a zero tensor as a stand-in. This meant the model was trained and evaluated on fabricated inputs without any warning, making it impossible to know how many records in a run were actually backed by real satellite data. This PR removes the zero-fallback entirely: records with missing tiles are now filtered out at __init__ time and a warning is logged with the count. __getitem__ is simplified to call load_tessera() directly, which also applies the correct centre-crop from BaseDataset. Two minor config fixes are included: a missing csv_name: null that could cause a confusing FileNotFoundError on first use, and a clarified comment about the size parameter.

## Summary
- Records missing a tessera `.npy` tile are now dropped at `__init__` time with a logged warning, instead of silently falling back to `torch.zeros` in `__getitem__`
- `__getitem__` now calls `self.load_tessera()` (applies center-crop from `BaseDataset`) instead of raw `load_npy()` with a manual zero-fallback
- `csv_name: null` added to `yield_africa_tessera.yaml` (was absent, causing a confusing error)
- Size comment in KEN config updated: size can be *smaller than* tile_size, not necessarily equal

## Test plan
- [X] Instantiate `YieldAfricaDataset` with a mix of present and absent tile paths; confirm dropped-record count in logs matches expectation
- [X] Confirm no zero-tensor samples appear in a training batch

## Before submitting

- [X] Did you make sure **title is self-explanatory** and **the description concisely explains the PR**?
- [X] Did you make sure your **PR does only one thing**, instead of bundling different changes together?
- [X] Did you list all the **breaking changes** introduced by this pull request?
- [X] Did you **test your PR locally** with `pytest` command?
