### PR TITLE
Add batch size finder

### DIFF
--- a/configs/callbacks/batch_size_finder.yaml
+++ b/configs/callbacks/batch_size_finder.yaml
@@ -1,0 +1,5 @@
+# https://lightning.ai/docs/pytorch/stable/api/lightning.pytorch.callbacks.BatchSizeFinder.html
+
+_target_: lightning.pytorch.callbacks.BatchSizeFinder
+mode: 'binsearch'
+init_val: 16

--- a/src/data/base_datamodule.py
+++ b/src/data/base_datamodule.py
@@ -27,6 +27,8 @@ class BaseDataModule(LightningDataModule):
         train_val_test_split: Tuple[float, float, float] = (0.7, 0.15, 0.15),
         num_workers: int = 0,
         pin_memory: bool = False,
+        persistent_workers: bool = False,
+        prefetch_factor: int | None = None,
         dataset_name: str = "base",
         split_mode: str = "random",
         save_split: bool = False,
@@ -43,6 +45,8 @@ class BaseDataModule(LightningDataModule):
             testing
         :param num_workers: number of workers for dataloader
         :param pin_memory: pin memory for dataloader
+        :param persistent_workers: keep DataLoader workers alive between epochs
+        :param persistent_workers:
         :param dataset_name: dataset name
         :param split_mode: data split mode: random/from_file
         :param save_split: if to save split file
@@ -55,7 +59,6 @@ class BaseDataModule(LightningDataModule):
         self.save_hyperparameters(logger=False)
 
         self.dataset: BaseDataset = dataset
-        self.batch_size_per_device: int = batch_size
 
         # Caption generation
         self.use_collate_fn: bool = self.dataset.use_aux_data
@@ -84,16 +87,19 @@ class BaseDataModule(LightningDataModule):
 
         # Set up the dataset (download requested modalities)
         self.dataset.setup()
-        self.setup_batch_size_per_device()
 
-    def setup_batch_size_per_device(self) -> None:
+    @property
+    def batch_size_per_device(self) -> None:
         """Divide batch size by the number of devices."""
-        if self.trainer is not None:
-            if self.hparams.batch_size % self.trainer.world_size != 0:
-                raise RuntimeError(
-                    f"Batch size ({self.hparams.batch_size}) is not divisible by the number of devices ({self.trainer.world_size})."
-                )
-            self.batch_size_per_device = self.hparams.batch_size // self.trainer.world_size
+        if self.trainer is None:
+            return self.hparams.batch_size
+
+        if self.hparams.batch_size % self.trainer.world_size != 0:
+            raise RuntimeError(f"Batch size ({self.hparams.batch_size}) is not divisible by the number of devices ({self.trainer.world_size}).")
+
+        return self.hparams.batch_size // self.trainer.world_size
+
+
 
     def split_data(self) -> None:
         """Split data into train, val and test.
@@ -355,9 +361,12 @@ class BaseDataModule(LightningDataModule):
         return DataLoader(
             dataset=self.data_train,
             batch_size=self.batch_size_per_device,
-            persistent_workers=True if self.hparams.num_workers > 0 else False,
+            persistent_workers=(
+                bool(self.hparams.persistent_workers) if self.hparams.num_workers > 0 else False
+            ),
             num_workers=self.hparams.num_workers,
             pin_memory=self.hparams.pin_memory,
+            prefetch_factor=(self.hparams.prefetch_factor if self.hparams.num_workers > 0 else None),
             shuffle=True,
             collate_fn=(
                 partial(
@@ -380,7 +389,8 @@ class BaseDataModule(LightningDataModule):
             batch_size=self.batch_size_per_device,
             num_workers=self.hparams.num_workers,
             pin_memory=self.hparams.pin_memory,
-            persistent_workers=True if self.hparams.num_workers > 0 else False,
+            persistent_workers=(bool(self.hparams.persistent_workers) if self.hparams.num_workers > 0 else False),
+            prefetch_factor=(self.hparams.prefetch_factor if self.hparams.num_workers > 0 else None),
             shuffle=False,
             collate_fn=(
                 partial(
@@ -403,6 +413,8 @@ class BaseDataModule(LightningDataModule):
             batch_size=self.batch_size_per_device,
             num_workers=self.hparams.num_workers,
             pin_memory=self.hparams.pin_memory,
+            persistent_workers=(bool(self.hparams.persistent_workers) if self.hparams.num_workers > 0 else False),
+            prefetch_factor=(self.hparams.prefetch_factor if self.hparams.num_workers > 0 else None),
             shuffle=False,
             collate_fn=(
                 partial(


### PR DESCRIPTION
## What does this PR do?

Builds on top of #107 

Adds Lightning-based batch size finder, which finds the largest batch size which fits before OOM. It will be used for contrastive training of the alignement model.

## Before submitting

- [x] Did you make sure **title is self-explanatory** and **the description concisely explains the PR**?
- [x] Did you make sure your **PR does only one thing**, instead of bundling different changes together?
- [x] Did you list all the **breaking changes** introduced by this pull request?
- [x] Did you **test your PR locally** with `pytest` command?
