### PR TITLE
Raname projectors_adaptors and BaseEncoder to projectors and BaseProj…

### DIFF
--- a/configs/experiment/alignment.yaml
+++ b/configs/experiment/alignment.yaml
@@ -16,7 +16,7 @@ model:
     _target_: src.models.components.geo_encoders.geoclip.GeoClipCoordinateEncoder
     geo_data_name: coords
   geo_adapter:
-    _target_: src.models.components.projectors_adapters.mlp_projector.MLPProjector
+    _target_: src.models.components.projectors.mlp_projector.MLPProjector
     nn_layers: 2
     hidden_dim: 512
     output_dim: 768

--- a/configs/experiment/alignment_template.yaml
+++ b/configs/experiment/alignment_template.yaml
@@ -28,7 +28,7 @@ model:
     _target_: src.models.components.geo_encoders.identity_encoder.IdentityEncoder
     geo_data_name: aef_avr
   geo_adapter:
-    _target_: src.models.components.projectors_adapters.mlp_projector.MLPProjector
+    _target_: src.models.components.projectors.mlp_projector.MLPProjector
     nn_layers: 2
     hidden_dim: 512
     #    output_dim: 1280 # TODO for LLM

--- a/configs/experiment/s2bms_align_avr_aef_clip_text.yaml
+++ b/configs/experiment/s2bms_align_avr_aef_clip_text.yaml
@@ -25,7 +25,7 @@ model:
     _target_: src.models.components.geo_encoders.identity_encoder.IdentityEncoder
     geo_data_name: aef_avr
   geo_adapter:
-    _target_: src.models.components.projectors_adapters.mlp_projector.MLPProjector
+    _target_: src.models.components.projectors.mlp_projector.MLPProjector
     nn_layers: 2
     hidden_dim: 512
     output_dim: 768

--- a/configs/experiment/s2bms_align_avr_aef_clip_text_1.yaml
+++ b/configs/experiment/s2bms_align_avr_aef_clip_text_1.yaml
@@ -25,7 +25,7 @@ model:
     _target_: src.models.components.geo_encoders.identity_encoder.IdentityEncoder
     geo_data_name: aef_avr
   geo_adapter:
-    _target_: src.models.components.projectors_adapters.mlp_projector.MLPProjector
+    _target_: src.models.components.projectors.mlp_projector.MLPProjector
     nn_layers: 2
     hidden_dim: 512
     output_dim: 768

--- a/configs/experiment/s2bms_align_avr_aef_clip_text_unlab.yaml
+++ b/configs/experiment/s2bms_align_avr_aef_clip_text_unlab.yaml
@@ -25,7 +25,7 @@ model:
     _target_: src.models.components.geo_encoders.identity_encoder.IdentityEncoder
     geo_data_name: aef_avr
   geo_adapter:
-    _target_: src.models.components.projectors_adapters.mlp_projector.MLPProjector
+    _target_: src.models.components.projectors.mlp_projector.MLPProjector
     nn_layers: 2
     hidden_dim: 512
     output_dim: 768

--- a/configs/experiment/s2bms_align_avr_aef_clip_text_unlab_1.yaml
+++ b/configs/experiment/s2bms_align_avr_aef_clip_text_unlab_1.yaml
@@ -25,7 +25,7 @@ model:
     _target_: src.models.components.geo_encoders.identity_encoder.IdentityEncoder
     geo_data_name: aef_avr
   geo_adapter:
-    _target_: src.models.components.projectors_adapters.mlp_projector.MLPProjector
+    _target_: src.models.components.projectors.mlp_projector.MLPProjector
     nn_layers: 2
     hidden_dim: 512
     output_dim: 768

--- a/configs/experiment/s2bms_align_avr_aef_llm.yaml
+++ b/configs/experiment/s2bms_align_avr_aef_llm.yaml
@@ -25,7 +25,7 @@ model:
     _target_: src.models.components.geo_encoders.identity_encoder.IdentityEncoder
     geo_data_name: aef_avr
   geo_adapter:
-    _target_: src.models.components.projectors_adapters.mlp_projector.MLPProjector
+    _target_: src.models.components.projectors.mlp_projector.MLPProjector
     nn_layers: 2
     hidden_dim: 512
     output_dim: 1280

--- a/src/models/components/projectors/base_projector.py
+++ b/src/models/components/projectors/base_projector.py
@@ -5,7 +5,7 @@ import torch
 from torch import nn
 
 
-class BaseEncoder(nn.Module, ABC):
+class BaseProjector(nn.Module, ABC):
     def __init__(self) -> None:
         super().__init__()
 

--- a/src/models/components/projectors/mlp_projector.py
+++ b/src/models/components/projectors/mlp_projector.py
@@ -3,10 +3,10 @@ from typing import List, override
 import torch
 from torch import nn
 
-from src.models.components.projectors_adapters.base_encoder import BaseEncoder
+from src.models.components.projectors.base_projector import BaseProjector
 
 
-class MLPProjector(BaseEncoder):
+class MLPProjector(BaseProjector):
     def __init__(
         self,
         output_dim: int,

--- a/src/models/text_alignment_model.py
+++ b/src/models/text_alignment_model.py
@@ -10,7 +10,7 @@ from src.models.components.metrics.contrastive_validation import (
     RetrievalContrastiveValidation,
 )
 from src.models.components.metrics.metrics_wrapper import MetricsWrapper
-from src.models.components.projectors_adapters.base_encoder import BaseEncoder
+from src.models.components.projectors.base_projector import BaseProjector
 from src.models.components.text_encoders.base_text_encoder import BaseTextEncoder
 
 
@@ -24,8 +24,8 @@ class TextAlignmentModel(BaseModel):
         scheduler: torch.optim.lr_scheduler,
         loss_fn: BaseLossFn,
         metrics: MetricsWrapper,
-        geo_adapter: BaseEncoder | None = None,
-        text_adapter: BaseEncoder | None = None,
+        geo_adapter: BaseProjector | None = None,
+        text_adapter: BaseProjector | None = None,
         num_classes: int | None = None,
         tabular_dim: int | None = None,
         ks: list[int] | None = [5, 10, 15],

--- a/tests/test_dynamic_gate_fusion_encoder.py
+++ b/tests/test_dynamic_gate_fusion_encoder.py
@@ -16,7 +16,8 @@ import torch
 from src.models.components.geo_encoders.base_geo_encoder import BaseGeoEncoder
 from src.models.components.geo_encoders.encoder_wrapper import EncoderWrapper
 from src.models.components.geo_encoders.tabular_encoder import TabularEncoder
-from src.models.components.projectors_adapters.mlp_projector import MLPProjector
+from src.models.components.projectors.mlp_projector import MLPProjector
+
 
 # ---------------------------------------------------------------------------
 # Minimal stub encoder for testing — outputs a fixed-size embedding.

--- a/tests/test_gated_fusion_encoder.py
+++ b/tests/test_gated_fusion_encoder.py
@@ -138,7 +138,7 @@ def test_with_tabular_encoder():
 
     Both branches projected to the same output_dim (32) via per-branch projectors.
     """
-    from src.models.components.projectors_adapters.mlp_projector import MLPProjector
+    from src.models.components.projectors.mlp_projector import MLPProjector
 
     tabular_dim = 23
     tab_enc = TabularEncoder(output_dim=32)


### PR DESCRIPTION
## What does this PR do?

Rename `projectors_adapters` and `BaseEncoder` to `projectors` and `BaseProjector`

## Before submitting

- [x] Did you make sure **title is self-explanatory** and **the description concisely explains the PR**?
- [x] Did you make sure your **PR does only one thing**, instead of bundling different changes together?
- [x] Did you list all the **breaking changes** introduced by this pull request?
- [x] Did you **test your PR locally** with `pytest` command?
