### PR TITLE
Fix tabular baseline

### DIFF
--- a/configs/experiment/s2bms_prediction/baselines/tabular_linear.yaml
+++ b/configs/experiment/s2bms_prediction/baselines/tabular_linear.yaml
@@ -1,0 +1,58 @@
+# @package _global_
+
+# to execute this experiment run:
+# python train.py experiment=example
+
+# tabular only
+
+defaults:
+  - override /model: s2bms_prediction
+  - override /data: s2bms_prediction
+  - override /metrics: s2bms_predictive
+
+tags:
+  - prediction
+  - tabular
+  - ${str:${seed}}
+
+experiment_name: tabular_baseline_linear
+
+model:
+  normalize_features: false
+  standardize_targets: false
+  geo_encoder:
+    _target_: src.models.components.geo_encoders.identity_encoder.IdentityEncoder
+    geo_data_name: s2bms_target
+  trainable_modules: [geo_encoder, prediction_head]
+  prediction_head:
+    _target_: src.models.components.pred_heads.linear_pred_head.LinearPredictionHead
+
+data:
+  dataset:
+    modalities:
+      coords:
+    use_features:
+      pattern: "^aux_(?!.*top).*"
+      stats_file: ${paths.data_dir}/s2bms/aux_stats/labelled.json
+    use_target_data: true
+    use_aux_data: false
+  caption_builder:
+  pin_memory: true
+  persistent_workers: True
+  num_workers: 11
+  batch_size: 128
+  saved_split_file_name: "s2bms_union_val_test.pth"
+
+logger:
+  wandb:
+    tags: ${tags}
+    group: "predictive"
+    project: "s2bms_prediction"
+  aim:
+    experiment: "predictive"
+
+hydra:
+  mode: MULTIRUN
+  sweeper:
+    params:
+      seed: 12345, 404, 654

--- a/configs/experiment/s2bms_prediction/baselines/tabular_mlp.yaml
+++ b/configs/experiment/s2bms_prediction/baselines/tabular_mlp.yaml
@@ -1,0 +1,61 @@
+# @package _global_
+
+# to execute this experiment run:
+# python train.py experiment=example
+
+# tabular only
+
+defaults:
+  - override /model: s2bms_prediction
+  - override /data: s2bms_prediction
+  - override /metrics: s2bms_predictive
+
+tags:
+  - prediction
+  - tabular
+  - ${str:${seed}}
+
+experiment_name: tabular_baseline_mlp${str:${model.prediction_head.hidden_dim}}
+
+model:
+  normalize_features: false
+  standardize_targets: false
+  geo_encoder:
+    _target_: src.models.components.geo_encoders.identity_encoder.IdentityEncoder
+    geo_data_name: s2bms_target
+  trainable_modules: [geo_encoder, prediction_head]
+  prediction_head:
+    _target_: src.models.components.pred_heads.mlp_pred_head.MLPPredictionHead
+    nn_layers: 2
+    dropout: 0.2
+
+data:
+  dataset:
+    modalities:
+      coords:
+    use_features:
+      pattern: "^aux_(?!.*top).*"
+      stats_file: ${paths.data_dir}/s2bms/aux_stats/labelled.json
+    use_target_data: true
+    use_aux_data: false
+  caption_builder:
+  pin_memory: true
+  persistent_workers: True
+  num_workers: 11
+  batch_size: 128
+  saved_split_file_name: "s2bms_union_val_test.pth"
+
+logger:
+  wandb:
+    tags: ${tags}
+    group: "predictive"
+    project: "s2bms_prediction"
+  aim:
+    experiment: "predictive"
+
+hydra:
+  mode: MULTIRUN
+  sweeper:
+    params:
+      seed: 12345, 404, 654
+      ++model.prediction_head.hidden_dim: 128, 256

--- a/src/data/base_dataset.py
+++ b/src/data/base_dataset.py
@@ -1,3 +1,4 @@
+import json
 import logging
 import os
 import re
@@ -204,11 +205,29 @@ class BaseDataset(Dataset, ABC):
                     ValueError('use_features should have "pattern" or "columns" defined'),
                 )
             self.feat_names = feat_names
+            self._feat_norm_setup()
             columns.extend(feat_names)
 
             self.tabular_dim = len(self.feat_names)  # drop any duplicates
 
         return list(set(columns))
+
+    def _feat_norm_setup(self):
+        """If statistics files provided for the features, read them into self.feat_stats
+        parameter."""
+
+        if "stats_file" in self.use_features:
+            with open(self.use_features["stats_file"]) as json_data:
+                d = json.load(json_data)
+
+            means = [d[f]["mean"] for f in self.feat_names]
+            stds = [d[f]["std"] if d[f]["std"] > 1e-8 else 1.0 for f in self.feat_names]
+
+            self._feat_mean = torch.tensor(means, dtype=torch.float32)
+            self._feat_std = torch.tensor(stds, dtype=torch.float32)
+        else:
+            self._feat_mean = None
+            self._feat_std = None
 
     def get_records(self):
         return self.df.loc[:, self.columns].to_dict("records")

--- a/src/data/butterfly_dataset.py
+++ b/src/data/butterfly_dataset.py
@@ -231,9 +231,11 @@ class ButterflyDataset(BaseDataset):
                     formatted_row["aux"][aux_cat] = [row[v] for v in vals]
 
         if self.use_features and self.feat_names:
-            formatted_row["eo"]["tabular"] = torch.tensor(
-                [row[k] for k in self.feat_names], dtype=torch.float32
-            )
+            raw = torch.tensor([row[k] for k in self.feat_names], dtype=torch.float32)
+            if self._feat_mean is not None and self._feat_std is not None:
+                formatted_row["eo"]["tabular"] = (raw - self._feat_mean) / self._feat_std
+            else:
+                formatted_row["eo"]["tabular"] = raw
 
         if self.return_name_loc:
             formatted_row["name_loc"] = row["name_loc"]

--- a/src/models/components/geo_encoders/identity_encoder.py
+++ b/src/models/components/geo_encoders/identity_encoder.py
@@ -17,14 +17,19 @@ class IdentityEncoder(BaseGeoEncoder):
         """
         super().__init__()
 
-        self.dict_n_bands_default = {"aef": 64, "tessera": 128, "aef_avr": 64, "tessera_avr": 128}
+        self.dict_n_bands_default = {
+            "aef": 64,
+            "tessera": 128,
+            "aef_avr": 64,
+            "tessera_avr": 128,
+            "s2bms_target": 87,
+        }
         self.allowed_geo_data_names: list[str] = list(self.dict_n_bands_default.keys())
         assert (
             geo_data_name in self.allowed_geo_data_names
         ), f"geo_data_name must be one of {self.allowed_geo_data_names}, got {geo_data_name}"
-        self.geo_data_name = geo_data_name
-
         self.output_dim = self.dict_n_bands_default[geo_data_name]
+        self.geo_data_name = geo_data_name if "target" not in geo_data_name else "tabular"
 
     @override
     def _setup(self) -> List[str]:


### PR DESCRIPTION
## What does this PR do?

- Simplified config files for LR and MLP regression for S2bms. 
- Included input variable standartisation based on aux stat files (generated and also used for the soft contrastive loss).
- Allow identity encoder to be used for tabular data

Fixes #\<issue_number>

## Before submitting

- [x] Did you make sure **title is self-explanatory** and **the description concisely explains the PR**?
- [x] Did you make sure your **PR does only one thing**, instead of bundling different changes together?
- [ ] Did you list all the **breaking changes** introduced by this pull request?
- [x] Did you **test your PR locally** with `pytest` command?
